### PR TITLE
fix: make Discord test token detection case-insensitive

### DIFF
--- a/src/platforms/validators/discord-credentials.validator.ts
+++ b/src/platforms/validators/discord-credentials.validator.ts
@@ -105,8 +105,9 @@ export class DiscordCredentialsValidator
     if (
       credentials.token &&
       typeof credentials.token === 'string' &&
-      (credentials.token.includes('test') ||
-        credentials.token.includes('example'))
+      (credentials.token.toLowerCase().includes('test') ||
+        credentials.token.toLowerCase().includes('example') ||
+        credentials.token.toLowerCase().includes('fake'))
     ) {
       warnings.push(
         'This appears to be a test/example token - ensure you use a real bot token',


### PR DESCRIPTION
## Summary

Fixes Discord credentials validator test failure by making test token detection case-insensitive.

## Changes

- Updated token detection to use `.toLowerCase()` for case-insensitive matching
- Added 'fake' as an additional test token pattern
- Ensures test tokens with uppercase letters (TEST, FAKE, EXAMPLE) are properly detected

## Test Results

All 12 Discord validator tests passing:

```
PASS  src/platforms/validators/discord-credentials.validator.spec.ts
  DiscordCredentialsValidator
    validateCredentials
      ✓ should validate correct Discord credentials
      ✓ should reject missing token
      ✓ should accept any non-empty token
      ✓ should reject non-string token
      ✓ should validate client ID format if provided
      ✓ should validate guild ID format if provided
      ✓ should validate intents array if provided
      ✓ should accept numeric intents
      ✓ should warn about test/example tokens
    getRequiredFields
      ✓ should return required fields
    getOptionalFields
      ✓ should return optional fields
    getExampleCredentials
      ✓ should return valid example credentials
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)