### PR TITLE
refactor: update organization to msgcore and API key prefix to msc_

### DIFF
--- a/.github/prompts/sdk-changelog.md
+++ b/.github/prompts/sdk-changelog.md
@@ -46,7 +46,7 @@ Generate a PR description for the **@msgcore/sdk** package based on actual code 
 [1-2 sentence description of what changed]
 
 **Version**: v$VERSION
-**Source**: [MsgCore Backend](https://github.com/filipexyz/msgcore)
+**Source**: [MsgCore Backend](https://github.com/msgcore/msgcore)
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ MsgCore supports three authentication methods:
 
 ## Generated Packages
 
-- [@msgcore/sdk](https://github.com/filipexyz/msgcore-sdk) - TypeScript client
-- [@msgcore/cli](https://github.com/filipexyz/msgcore-cli) - Command-line tool
-- [n8n-nodes-msgcore](https://github.com/filipexyz/n8n-nodes-msgcore) - Visual automation
+- [@msgcore/sdk](https://github.com/msgcore/msgcore-sdk) - TypeScript client
+- [@msgcore/cli](https://github.com/msgcore/msgcore-cli) - Command-line tool
+- [n8n-nodes-msgcore](https://github.com/msgcore/n8n-nodes-msgcore) - Visual automation
 
 ## License
 

--- a/docs/EMAIL_PLATFORM_GUIDE.md
+++ b/docs/EMAIL_PLATFORM_GUIDE.md
@@ -390,7 +390,7 @@ Send OTP codes (but use dedicated services for production).
 
 - **Documentation:** https://docs.msgcore.dev
 - **Discord:** https://discord.gg/bQPsvycW
-- **GitHub Issues:** https://github.com/filipexyz/msgcore
+- **GitHub Issues:** https://github.com/msgcore/msgcore
 
 ---
 

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -324,7 +324,7 @@ npm link
 ```bash
 # Set API URL and key
 msgcore config set apiUrl http://localhost:3000
-msgcore config set apiKey gk_dev_your_api_key_here
+msgcore config set apiKey msc_dev_your_api_key_here
 ```
 
 ### Usage

--- a/src/api-keys/api-keys.service.spec.ts
+++ b/src/api-keys/api-keys.service.spec.ts
@@ -66,9 +66,9 @@ describe('ApiKeysService', () => {
 
         environment: 'development',
       };
-      const mockApiKey = 'gk_test_abc123';
+      const mockApiKey = 'msc_test_abc123';
       const mockKeyHash = 'hashed_key';
-      const mockKeyPrefix = 'gk_test_abc1';
+      const mockKeyPrefix = 'msc_test_abc1';
 
       mockPrismaService.project.findUnique.mockResolvedValue(mockProject);
       (CryptoUtil.generateApiKey as jest.Mock).mockReturnValue(mockApiKey);
@@ -139,9 +139,9 @@ describe('ApiKeysService', () => {
         id: 'project-id',
         environment: 'test',
       });
-      (CryptoUtil.generateApiKey as jest.Mock).mockReturnValue('gk_test_key');
+      (CryptoUtil.generateApiKey as jest.Mock).mockReturnValue('msc_test_key');
       (CryptoUtil.hashApiKey as jest.Mock).mockReturnValue('hash');
-      (CryptoUtil.getKeyPrefix as jest.Mock).mockReturnValue('gk_test_');
+      (CryptoUtil.getKeyPrefix as jest.Mock).mockReturnValue('msc_test_');
       (CryptoUtil.getKeySuffix as jest.Mock).mockReturnValue('wxyz');
 
       mockPrismaService.apiKey.create.mockResolvedValue({
@@ -175,7 +175,7 @@ describe('ApiKeysService', () => {
         {
           id: 'key-1',
           name: 'Key 1',
-          keyPrefix: 'gk_test_abcd',
+          keyPrefix: 'msc_test_abcd',
           keySuffix: 'abcd',
           environment: 'test',
           lastUsedAt: null,
@@ -189,7 +189,7 @@ describe('ApiKeysService', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0]).toHaveProperty('maskedKey');
-      expect(result[0].maskedKey).toBe('gk_test_abcd...abcd');
+      expect(result[0].maskedKey).toBe('msc_test_abcd...abcd');
     });
 
     it('should throw NotFoundException when project does not exist', async () => {
@@ -260,7 +260,7 @@ describe('ApiKeysService', () => {
 
   describe('validateApiKey', () => {
     it('should validate and return key data for valid API key', async () => {
-      const apiKey = 'gk_test_valid';
+      const apiKey = 'msc_test_valid';
       const keyHash = 'hashed_valid';
 
       (CryptoUtil.hashApiKey as jest.Mock).mockReturnValue(keyHash);

--- a/src/common/guards/app-auth.guard.spec.ts
+++ b/src/common/guards/app-auth.guard.spec.ts
@@ -83,7 +83,7 @@ describe('AppAuthGuard', () => {
     });
 
     it('should authenticate with valid API key', async () => {
-      const mockApiKey = 'gk_test_validkey123';
+      const mockApiKey = 'msc_test_validkey123';
       const mockValidatedKey = {
         id: 'key-id',
         project: { id: 'project-id', name: 'Test Project' },

--- a/src/common/utils/crypto.util.ts
+++ b/src/common/utils/crypto.util.ts
@@ -56,7 +56,7 @@ export class CryptoUtil {
     };
 
     const randomPart = randomBytes(32).toString('base64url');
-    return `gk_${envPrefix[environment]}_${randomPart}`;
+    return `msc_${envPrefix[environment]}_${randomPart}`;
   }
 
   static hashApiKey(key: string): string {

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -174,7 +174,7 @@ export class McpController {
     let scopes: string[] = [];
     let project: { id: string } | undefined;
     if (apiKeyHeader) {
-      // Extract key hash from the API key (format: gk_live_xxx or gk_test_xxx)
+      // Extract key hash from the API key (format: msc_live_xxx or msc_test_xxx)
       const keyHash = createHash('sha256').update(apiKeyHeader).digest('hex');
 
       const apiKey = await this.prisma.apiKey.findUnique({

--- a/test/cli-integration.e2e-spec.ts
+++ b/test/cli-integration.e2e-spec.ts
@@ -295,13 +295,13 @@ describe('CLI Integration Tests (e2e)', () => {
 
       // Set API key
       const { stdout: setOutput } = await execAsync(
-        `node ${cliIndexPath} config set apiKey gk_test_secret_key_12345`,
+        `node ${cliIndexPath} config set apiKey msc_test_secret_key_12345`,
         { cwd: generatedCliDir, timeout: 5000, env },
       );
 
       expect(setOutput).toContain('Set apiKey');
       expect(setOutput).toContain('***');
-      expect(setOutput).not.toContain('gk_test_secret_key_12345');
+      expect(setOutput).not.toContain('msc_test_secret_key_12345');
 
       // Get API key
       const { stdout: getOutput } = await execAsync(
@@ -311,7 +311,7 @@ describe('CLI Integration Tests (e2e)', () => {
 
       expect(getOutput).toContain('apiKey');
       expect(getOutput).toContain('***');
-      expect(getOutput).not.toContain('gk_test_secret_key_12345');
+      expect(getOutput).not.toContain('msc_test_secret_key_12345');
     }, 30000);
 
     it('should list all configuration', async () => {
@@ -344,7 +344,7 @@ describe('CLI Integration Tests (e2e)', () => {
       const env = { ...process.env, HOME: testOutputDir };
 
       // Set a config value
-      await execAsync(`node ${cliIndexPath} config set apiKey gk_test_key`, {
+      await execAsync(`node ${cliIndexPath} config set apiKey msc_test_key`, {
         cwd: generatedCliDir,
         timeout: 5000,
         env,

--- a/test/integration/app.e2e-spec.ts
+++ b/test/integration/app.e2e-spec.ts
@@ -233,7 +233,7 @@ describe('MsgCore API (e2e)', () => {
           .expect(201)
           .expect((res) => {
             expect(res.body).toHaveProperty('key');
-            expect(res.body.key).toMatch(/^gk_dev_/);
+            expect(res.body.key).toMatch(/^msc_dev_/);
             expect(res.body).toHaveProperty('name', 'New API Key');
             expect(res.body.scopes).toEqual(['messages:write']);
           });
@@ -288,7 +288,7 @@ describe('MsgCore API (e2e)', () => {
             expect(res.body.length).toBeGreaterThan(0);
             expect(res.body[0]).toHaveProperty('name');
             expect(res.body[0]).toHaveProperty('maskedKey');
-            expect(res.body[0].maskedKey).toMatch(/^gk_dev_.*\.\.\..*$/);
+            expect(res.body[0].maskedKey).toMatch(/^msc_dev_.*\.\.\..*$/);
           });
       });
 
@@ -343,7 +343,7 @@ describe('MsgCore API (e2e)', () => {
           .expect(200)
           .expect((res) => {
             expect(res.body).toHaveProperty('key');
-            expect(res.body.key).toMatch(/^gk_dev_/);
+            expect(res.body.key).toMatch(/^msc_dev_/);
             expect(res.body).toHaveProperty('name', 'Key to Roll');
             expect(res.body).toHaveProperty('oldKeyRevokedAt');
           });

--- a/tools/generators/cli-generator.ts
+++ b/tools/generators/cli-generator.ts
@@ -777,11 +777,11 @@ export function handleError(error: any): void {
         license: 'MIT',
         repository: {
           type: 'git',
-          url: 'https://github.com/filipexyz/msgcore-cli.git',
+          url: 'https://github.com/msgcore/msgcore-cli.git',
         },
-        homepage: 'https://github.com/filipexyz/msgcore-cli',
+        homepage: 'https://github.com/msgcore/msgcore-cli',
         bugs: {
-          url: 'https://github.com/filipexyz/msgcore-cli/issues',
+          url: 'https://github.com/msgcore/msgcore-cli/issues',
         },
       },
       null,

--- a/tools/generators/sdk-generator.ts
+++ b/tools/generators/sdk-generator.ts
@@ -670,11 +670,11 @@ export const CONTRACTS_COUNT = ${contracts.length};
         license: 'MIT',
         repository: {
           type: 'git',
-          url: 'https://github.com/filipexyz/msgcore-sdk.git',
+          url: 'https://github.com/msgcore/msgcore-sdk.git',
         },
-        homepage: 'https://github.com/filipexyz/msgcore-sdk',
+        homepage: 'https://github.com/msgcore/msgcore-sdk',
         bugs: {
-          url: 'https://github.com/filipexyz/msgcore-sdk/issues',
+          url: 'https://github.com/msgcore/msgcore-sdk/issues',
         },
       },
       null,

--- a/tools/generators/templates/cli/README.template.md
+++ b/tools/generators/templates/cli/README.template.md
@@ -17,7 +17,7 @@ npm install -g @msgcore/cli
 ```bash
 # Configure CLI (stores in ~/.msgcore/config.json with secure permissions)
 msgcore config set apiUrl https://api.msgcore.dev
-msgcore config set apiKey gk_live_your_api_key_here
+msgcore config set apiKey msc_live_your_api_key_here
 msgcore config set defaultProject my-project
 
 # Verify configuration
@@ -32,7 +32,7 @@ msgcore messages send --target "platform-id:user:123" --text "Hello!"
 ```bash
 # Set environment variables (override config file)
 export MSGCORE_API_URL="https://api.msgcore.dev"
-export MSGCORE_API_KEY="gk_live_your_api_key_here"
+export MSGCORE_API_KEY="msc_live_your_api_key_here"
 export MSGCORE_DEFAULT_PROJECT="my-project"
 
 # Use CLI
@@ -70,7 +70,7 @@ This allows you to:
 ```bash
 # Set configuration values
 msgcore config set apiUrl https://api.msgcore.dev
-msgcore config set apiKey gk_live_your_api_key_here
+msgcore config set apiKey msc_live_your_api_key_here
 msgcore config set defaultProject my-project
 msgcore config set outputFormat json
 
@@ -93,7 +93,7 @@ Stored in `~/.msgcore/config.json` with **secure permissions (600)**:
 ```json
 {
   "apiUrl": "https://api.msgcore.dev",
-  "apiKey": "gk_live_your_api_key_here",
+  "apiKey": "msc_live_your_api_key_here",
   "defaultProject": "my-project",
   "outputFormat": "table"
 }
@@ -112,7 +112,7 @@ Environment variables have **highest priority**:
 
 ```bash
 export MSGCORE_API_URL="https://api.msgcore.dev"
-export MSGCORE_API_KEY="gk_live_your_api_key_here"
+export MSGCORE_API_KEY="msc_live_your_api_key_here"
 export MSGCORE_JWT_TOKEN="your-jwt-token"  # Alternative to API key
 export MSGCORE_DEFAULT_PROJECT="my-project"
 export MSGCORE_OUTPUT_FORMAT="json"        # or "table"
@@ -153,7 +153,7 @@ echo $RESULT | jq '.jobId'
 ## Links
 
 - [Documentation](https://docs.msgcore.dev)
-- [GitHub](https://github.com/filipexyz/msgcore-cli)
+- [GitHub](https://github.com/msgcore/msgcore-cli)
 - [npm](https://www.npmjs.com/package/@msgcore/cli)
 - [Discord Community](https://discord.gg/bQPsvycW)
 

--- a/tools/generators/templates/n8n/README.template.md
+++ b/tools/generators/templates/n8n/README.template.md
@@ -43,7 +43,7 @@ npm install n8n-nodes-msgcore
 The node requires MsgCore API credentials:
 
 1. **API URL**: Your MsgCore API endpoint (e.g., `https://api.msgcore.dev`)
-2. **API Key**: Your MsgCore API key (starts with `gk_`)
+2. **API Key**: Your MsgCore API key (starts with `msc_`)
 
 ### Setting up Credentials in n8n
 
@@ -84,7 +84,7 @@ The node requires MsgCore API credentials:
 
 - [n8n Community Nodes](https://www.npmjs.com/package/n8n-nodes-msgcore)
 - [MsgCore Documentation](https://docs.msgcore.dev)
-- [GitHub](https://github.com/filipexyz/n8n-nodes-msgcore)
+- [GitHub](https://github.com/msgcore/n8n-nodes-msgcore)
 - [Discord Community](https://discord.gg/bQPsvycW)
 
 ## License

--- a/tools/generators/templates/sdk/README.template.md
+++ b/tools/generators/templates/sdk/README.template.md
@@ -17,7 +17,7 @@ import { MsgCore } from '@msgcore/sdk';
 
 const gk = new MsgCore({
   apiUrl: 'https://api.msgcore.dev',
-  apiKey: 'gk_live_your_api_key_here',
+  apiKey: 'msc_live_your_api_key_here',
 });
 
 // Send a message
@@ -46,7 +46,7 @@ const result = await gk.messages.send({
 ```typescript
 const gk = new MsgCore({
   apiUrl: 'https://api.msgcore.dev',
-  apiKey: 'gk_live_your_api_key_here',
+  apiKey: 'msc_live_your_api_key_here',
   defaultProject: 'my-project', // optional
 });
 ```
@@ -81,7 +81,7 @@ try {
 ## Links
 
 - [Documentation](https://docs.msgcore.dev)
-- [GitHub](https://github.com/filipexyz/msgcore-sdk)
+- [GitHub](https://github.com/msgcore/msgcore-sdk)
 - [npm](https://www.npmjs.com/package/@msgcore/sdk)
 - [Discord Community](https://discord.gg/bQPsvycW)
 


### PR DESCRIPTION
## Summary

- Updated all GitHub repository references from `filipexyz` to `msgcore` organization
- Changed API key prefix from `gk_` to `msc_` for better brand clarity and uniqueness

## Changes

**Organization Updates:**
- README.md - Updated SDK, CLI, and n8n package repository URLs
- Documentation files - Updated GitHub links
- Generator templates - Updated repository references in package.json generation
- Changelog prompts - Updated source repository references

**API Key Prefix Updates (gk_ → msc_):**
- `src/common/utils/crypto.util.ts` - Core key generation logic
- All test files - Updated test expectations
- Documentation templates - Updated examples
- MCP integration docs - Updated configuration examples

## Test Plan

- [x] All file references updated
- [x] No remaining `filipexyz` references
- [x] No remaining `gk_` prefix references
- [x] Changes are backward compatible (existing keys continue to work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)