### PR TITLE
feat: Docker Hub publishing workflow with standardized port configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,13 @@ services:
       retries: 5
 
   app:
-    image: msgcore/msgcore:${MSGCORE_VERSION:-latest}
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      args:
+        MSGCORE_API_URL: ${MSGCORE_API_URL:-http://localhost:7890}
+        MSGCORE_API_VERSION: v1
+        MSGCORE_ENV: production
     container_name: msgcore-app
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions workflow to build and publish Docker images to Docker Hub with AI-generated changelogs, and standardizes port configuration across the application.

## Changes

### Docker Publishing Workflow
- ✅ Manual workflow to build and publish to `msgcore/msgcore` on Docker Hub
- ✅ Multi-platform builds (linux/amd64, linux/arm64)
- ✅ AI-generated changelogs using Claude Code
- ✅ Automatic git tag and GitHub release creation
- ✅ Version extracted from package.json

### Port Standardization
- ✅ External port: 7890
- ✅ Internal backend port: 3000
- ✅ nginx configured to listen on 7890 and proxy to backend:3000
- ✅ Updated docker-compose.yml, Dockerfile, nginx.conf.template, docker-entrypoint.sh

### Docker Build Fixes
- ✅ Removed `:standalone` suffix from contract extraction
- ✅ Removed `|| true` error suppressions for proper failure handling
- ✅ Deleted redundant root Dockerfile
- ✅ Fixed nginx.conf path in Dockerfile

## Prerequisites

Before running the workflow, add these GitHub repository secrets:
- `DOCKER_USERNAME` - Docker Hub username
- `DOCKER_PASSWORD` - Docker Hub access token

## Workflow Usage

1. Go to Actions → "Build and Publish Docker Image"
2. Click "Run workflow"
3. Select branch: `main`
4. Enable "Publish to Docker Hub"
5. Click "Run workflow"

## After First Publish

Once the first Docker image is published to Docker Hub, we can update docker-compose.yml to use `image: msgcore/msgcore:latest` instead of `build:`.

## Test Plan

- [x] Docker compose builds successfully
- [x] All ports configured correctly (7890 external, 3000 internal)
- [ ] Workflow publishes to Docker Hub (requires secrets setup)
- [ ] Git tags and releases created automatically