### PR TITLE
fix: use published Docker image and prevent build output in changelogs

### DIFF
--- a/.github/prompts/docker-changelog.md
+++ b/.github/prompts/docker-changelog.md
@@ -103,6 +103,9 @@ docker pull msgcore/msgcore:latest
 
 ## Important Notes
 
+- **ONLY use git commands**: Analyze ONLY git log and git diff output - ignore ALL other terminal output
+- **NO Docker output**: Do NOT include Docker build logs, pull logs, or any Docker command output
+- **NO random terminal output**: Ignore bash prompts, environment variables, or any non-git data
 - **Be truthful**: Only include changes that actually happened (based on git log/diff)
 - **Group logically**: Similar changes should be grouped together
 - **User perspective**: Write for users deploying the image, not developers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,13 +37,7 @@ services:
       retries: 5
 
   app:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile
-      args:
-        MSGCORE_API_URL: ${MSGCORE_API_URL:-http://localhost:7890}
-        MSGCORE_API_VERSION: v1
-        MSGCORE_ENV: production
+    image: msgcore/msgcore:${MSGCORE_VERSION:-latest}
     container_name: msgcore-app
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary

Switch docker-compose.yml to use the published Docker image from Docker Hub instead of building locally, and improve changelog generation to exclude Docker build output.

## Changes

### Docker Compose
- ✅ Changed from `build:` to `image: msgcore/msgcore:${MSGCORE_VERSION:-latest}`
- ✅ Now pulls from Docker Hub instead of building locally
- ✅ Supports version override via `MSGCORE_VERSION` environment variable

### Changelog Prompt
- ✅ Added explicit instructions to ignore Docker build output
- ✅ Prevents Docker pull/build logs from appearing in release notes
- ✅ Focus only on git log and git diff output

## Benefits

- **Faster startup** - No need to build locally, just pull published image
- **Consistent deployments** - Everyone uses the same published image
- **Cleaner changelogs** - Only git changes, no Docker noise
- **Production ready** - Following industry best practices (n8n pattern)

## Testing

```bash
# Pull and run published image
docker compose pull
docker compose up -d

# Or use specific version
MSGCORE_VERSION=1.0.0 docker compose up -d
```

## Related

- Fixes changelog issue from #12 where Docker build output appeared in release notes
- Completes Docker publishing workflow implementation