### PR TITLE
fix: remove nginx template complexity and hardcode port 3000

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,7 +95,7 @@ COPY --from=backend-builder /app/backend/package*.json ./backend/
 COPY --from=web-builder /app/web/dist /usr/share/nginx/html
 
 # Copy nginx configuration
-COPY docker/nginx.conf.template /etc/nginx/nginx.conf
+COPY docker/nginx.conf /etc/nginx/nginx.conf
 
 # Copy entrypoint script
 COPY docker/docker-entrypoint.sh /docker-entrypoint.sh

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -29,11 +29,6 @@ trap shutdown SIGTERM SIGINT
 
 # Get backend port from environment (default 3000)
 BACKEND_PORT=${PORT:-3000}
-export BACKEND_PORT
-
-# Generate nginx config with environment variables
-echo "Generating nginx configuration..."
-envsubst '${BACKEND_PORT}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
 # Start backend
 echo "Starting backend API on port $BACKEND_PORT..."

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -33,9 +33,9 @@ http {
                application/rss+xml font/truetype font/opentype
                application/vnd.ms-fontobject image/svg+xml;
 
-    # Backend upstream (port from environment variable, default 3000)
+    # Backend upstream
     upstream backend {
-        server localhost:${BACKEND_PORT};
+        server localhost:3000;
         keepalive 32;
     }
 


### PR DESCRIPTION
## Summary

Simplify nginx configuration by removing template complexity and hardcoding the standardized backend port (3000).

## Changes

- ✅ Renamed `nginx.conf.template` → `nginx.conf`
- ✅ Hardcoded backend port to 3000 instead of using `${BACKEND_PORT}` variable
- ✅ Removed `envsubst` complexity from `docker-entrypoint.sh`
- ✅ Updated Dockerfile to copy final `nginx.conf`

## Why?

- Port 3000 is now standardized across the application
- No need for runtime environment variable substitution
- Simpler, more reliable Docker container startup
- Fixes the "can't open /etc/nginx/nginx.conf.template" error

## Testing

```bash
docker compose up -d
# nginx starts successfully with hardcoded port
```