### PR TITLE
fix: MCP JSON Schema compliance and nginx port configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,9 @@ services:
       retries: 5
 
   app:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
     image: msgcore/msgcore:${MSGCORE_VERSION:-latest}
     container_name: msgcore-app
     restart: unless-stopped

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -35,7 +35,7 @@ http {
 
     # Backend upstream
     upstream backend {
-        server localhost:3000;
+        server localhost:7890;
         keepalive 32;
     }
 


### PR DESCRIPTION
## Summary

- Fixed MCP tool schema generation to comply with JSON Schema draft 2020-12
- Updated nginx port configuration from 3000 to 7890
- Added build context to docker-compose for local development

## Problem

Claude CLI was throwing error:
```
tools.22.custom.input_schema: JSON schema is invalid. It must match JSON Schema draft 2020-12
```

## Solution

**MCP Schema Fixes:**
- Add `items` property to array types (required by JSON Schema 2020-12)
- Add `additionalProperties: true` to object types
- Handle empty properties with additionalProperties flag
- Ensures all generated schemas are spec-compliant

**Port Configuration:**
- Updated nginx backend upstream from `localhost:3000` to `localhost:7890`
- Aligns internal container routing with exposed port
- Ensures proper request forwarding

## Testing

- ✅ All 713 unit tests passing
- ✅ All e2e tests passing
- ✅ Build successful
- ✅ Pre-commit hooks passed (linting, formatting, tests)

## Files Changed

- `src/mcp/services/mcp-tool-registry.service.ts` - Fixed JSON Schema generation
- `docker/nginx.conf` - Updated backend upstream port
- `docker-compose.yml` - Added build context