### PR TITLE
Fix changelog prompts to remove variable syntax

### DIFF
--- a/.github/prompts/cli-changelog.md
+++ b/.github/prompts/cli-changelog.md
@@ -1,101 +1,36 @@
-# CLI Changelog Generation
+# Generate CLI Package PR Description
 
-Generate a PR description for the **@msgcore/cli** package based on actual code changes.
+You are creating a pull request for the **@msgcore/cli** package. The repository has been cloned to `cli-repo/` and all changes are staged in git.
 
-## Your Task
+## Task
 
-1. **Analyze the git diff** to see what actually changed:
+Analyze what changed in this CLI update and write a pull request description that will help reviewers understand the changes.
 
-   ```bash
-   cd $GITHUB_WORKSPACE/cli-repo
-   git diff --staged
-   ```
+## Steps
 
-2. **Understand the changes** - Look for:
-   - New commands
-   - Updated dependencies
-   - Command structure changes
-   - Flag/option changes
-   - Breaking changes
+1. Navigate to `cli-repo/` directory
+2. Review the staged git changes to understand what's new or different
+3. Check `package.json` for the version number
+4. Write two output files:
+   - `/tmp/cli-pr-title.txt` - A single-line PR title (no emojis)
+   - `/tmp/cli-pr-body.md` - Full PR description in markdown
 
-3. **Write concise output files**:
-   - `/tmp/cli-pr-title.txt` - One line title (no emojis)
-   - `/tmp/cli-pr-body.md` - Markdown PR description
+## PR Description Requirements
 
-## Output Guidelines
+The PR body should include:
+- Brief summary of changes (1-2 sentences)
+- Version number from package.json
+- Source attribution: `**Source**: [MsgCore Backend](https://github.com/msgcore/msgcore)`
+- Specific changes found in the diff (new commands, flag updates, dependency changes)
+- Usage examples for new commands if applicable
+- Breaking changes section if applicable
+- Migration guide if breaking changes exist
 
-**Title** (`/tmp/cli-pr-title.txt`):
+## Quality Guidelines
 
-- One line, descriptive, no emojis
-- Focus on the MAIN change
-- Examples: "Update CLI dependencies", "Add message commands", "Fix config handling"
-
-**Body** (`/tmp/cli-pr-body.md`):
-
-- Start with brief summary
-- List only ACTUAL changes from git diff
-- Include version info using $VERSION: `**Version**: v$VERSION`
-- Link to source backend: `**Source**: [MsgCore Backend](https://github.com/msgcore/msgcore)`
-- Keep it concise and direct
-
-## Structure (adapt as needed)
-
-````markdown
-## Summary
-
-[1-2 sentence description of what changed]
-
-**Version**: v$VERSION
-**Source**: [MsgCore Backend](https://github.com/msgcore/msgcore)
-
-### Changes
-
-[List actual changes - be specific and direct]
-
-- If new commands: list them with brief description
-- If dependency updates: list old→new versions
-- If breaking changes: explain clearly
-- If bug fixes: mention what was fixed
-
-### Usage Examples (only if new features)
-
-```bash
-# Show actual new commands if applicable
-msgcore new-command --option value
-```
-````
-
-### Migration (only if breaking changes)
-
-[Instructions if needed]
-
-```
-
-## Important Rules
-
-✅ **DO**:
-- Be flexible - adapt structure to fit actual changes
-- Focus on what matters - skip sections if not applicable
-- Be direct and concise
-- Use actual command names from git diff
-- Include only relevant information
-- Show real command examples if adding new features
-
-❌ **DON'T**:
-- Add sections that don't apply
-- Include placeholder text like "X commands generated" if not relevant
-- Add generic "improvements" that aren't real
-- Use rigid template when simple is better
-- Hallucinate commands
-
-## Environment Variables
-
-Available as shell environment variables (access with `$VARIABLE_NAME`):
-
-- `$VERSION` - Package version (e.g., "1.2.1")
-- `$COMMIT_SHA` - Commit hash (e.g., "a1b2c3d")
-- `$COMMIT_MSG` - Commit message
-- `$GITHUB_WORKSPACE` - Workspace directory
-
-**IMPORTANT**: Use these actual values in your output, not placeholder text!
-```
+- Be accurate - only describe changes you see in the git diff
+- Be specific - use actual command names, flag names, version numbers
+- Be concise - focus on what matters to CLI users
+- Adapt the structure to fit the actual changes (skip sections that don't apply)
+- Show real command examples if new features were added
+- No hallucinations - if you don't see it in the diff, don't mention it

--- a/.github/prompts/docker-changelog.md
+++ b/.github/prompts/docker-changelog.md
@@ -1,128 +1,42 @@
-# Docker Release Changelog Generation
+# Generate Docker Release Changelog
 
-Generate a release changelog for the **MsgCore Docker image** based on git changes since the last release.
+You are creating a GitHub release for the **MsgCore Docker image**. Analyze the git history to understand what changed since the last release.
 
-## Your Task
+## Task
 
-1. **Analyze git changes** since the last tag:
+Review the commits and changes in the MsgCore repository and write release notes that will help users understand what's new in this Docker image version.
 
-   ```bash
-   cd $GITHUB_WORKSPACE
+## Steps
 
-   if [ "$LAST_TAG" = "initial" ]; then
-     echo "Initial release - analyzing all commits"
-     git log --oneline --no-merges
-   else
-     echo "Analyzing changes since $LAST_TAG"
-     git log --oneline --no-merges "$LAST_TAG..HEAD"
-     git diff --stat "$LAST_TAG..HEAD"
-   fi
-   ```
+1. Check `package.json` for the current version number
+2. Use git log to identify changes since the last release tag
+3. Categorize the changes (features, fixes, breaking changes, dependencies, security)
+4. Write two output files:
+   - `/tmp/docker-tag-title.txt` - A single-line release title (no emojis, no version)
+   - `/tmp/docker-tag-body.md` - Full release notes in markdown
 
-2. **Categorize changes** - Look for:
-   - **Features**: New functionality, endpoints, platforms
-   - **Fixes**: Bug fixes, improvements
-   - **Breaking Changes**: API changes, removed features
-   - **Dependencies**: Updated packages
-   - **Performance**: Optimizations
-   - **Security**: Security fixes
-   - **Documentation**: Docs updates
+## Release Notes Requirements
 
-3. **Write concise output files**:
-   - `/tmp/docker-tag-title.txt` - One line title (no emojis, no version number)
-   - `/tmp/docker-tag-body.md` - Markdown release notes
+The release body should include:
+- Brief summary of this release (1-2 sentences)
+- Version number from package.json
+- Changes grouped by category:
+  - ✨ Features (new functionality)
+  - 🐛 Fixes (bug fixes and improvements)
+  - ⚠️ Breaking Changes (API changes requiring user action)
+  - 📦 Dependencies (updated packages)
+  - 🔒 Security (security fixes)
+- Docker pull command with correct version
+- Upgrade instructions if breaking changes exist
+- Link to full changelog comparing tags
 
-## Output Guidelines
+## Quality Guidelines
 
-**Title** (`/tmp/docker-tag-title.txt`):
-
-- One line, descriptive, no emojis, no version
-- Focus on the MAIN theme of this release
-- Examples: "Add webhook support and fix message delivery", "Platform improvements and bug fixes", "Initial release"
-
-**Body** (`/tmp/docker-tag-body.md`):
-
-- Start with brief summary
-- Group changes by category (Features, Fixes, etc.)
-- Use bullet points for each change
-- Include breaking changes section if any
-- Add upgrade instructions if needed
-- Keep it concise and user-focused
-
-## Structure
-
-````markdown
-## Summary
-
-[1-2 sentence description of this release]
-
-**Version**: v$VERSION
-
-## Changes
-
-### ✨ Features
-
-- New feature description
-- Another feature
-
-### 🐛 Fixes
-
-- Fix description
-- Another fix
-
-### ⚠️ Breaking Changes
-
-- Breaking change description with migration guide
-
-### 📦 Dependencies
-
-- Updated dependency X to vY.Z
-
-### 🔒 Security
-
-- Security fix description
-
-## Docker Image
-
-```bash
-docker pull msgcore/msgcore:$VERSION
-# or
-docker pull msgcore/msgcore:latest
-```
-````
-
-## Upgrade Instructions
-
-[If there are breaking changes or migration steps needed]
-
----
-
-**Full Changelog**: https://github.com/msgcore/msgcore/compare/LAST_TAG...v$VERSION
-
-````
-
-## Important Notes
-
-- **ONLY use git commands**: Analyze ONLY git log and git diff output - ignore ALL other terminal output
-- **NO Docker output**: Do NOT include Docker build logs, pull logs, or any Docker command output
-- **NO random terminal output**: Ignore bash prompts, environment variables, or any non-git data
-- **Be truthful**: Only include changes that actually happened (based on git log/diff)
-- **Group logically**: Similar changes should be grouped together
-- **User perspective**: Write for users deploying the image, not developers
-- **Breaking changes**: Always highlight these prominently
-- **No fluff**: Skip sections with no changes
-
-## Example Analysis Commands
-
-```bash
-# View commit messages
-git log --oneline --no-merges "$LAST_TAG..HEAD"
-
-# See file changes
-git diff --name-status "$LAST_TAG..HEAD"
-
-# See detailed changes in specific areas
-git log --no-merges --grep="feat\|fix\|breaking" "$LAST_TAG..HEAD"
-````
-
-Now analyze the changes and generate the changelog files.
+- Be accurate - only describe changes found in git history
+- Be specific - mention actual features, files, or API endpoints that changed
+- Be user-focused - write for people deploying the Docker image, not developers
+- Ignore non-git output (no Docker build logs, bash prompts, or other terminal noise)
+- Group similar changes together logically
+- Skip sections with no relevant changes
+- Highlight breaking changes prominently
+- No hallucinations - if you don't see it in git history, don't mention it

--- a/.github/prompts/n8n-changelog.md
+++ b/.github/prompts/n8n-changelog.md
@@ -1,98 +1,36 @@
-# n8n Changelog Generation
+# Generate n8n Package PR Description
 
-Generate a PR description for the **n8n-nodes-msgcore** package based on actual code changes.
+You are creating a pull request for the **n8n-nodes-msgcore** package. The repository has been cloned to `n8n-repo/` and all changes are staged in git.
 
-## Your Task
+## Task
 
-1. **Analyze the git diff** to see what actually changed:
+Analyze what changed in this n8n node update and write a pull request description that will help reviewers understand the changes.
 
-   ```bash
-   cd $GITHUB_WORKSPACE/n8n-repo
-   git diff --staged
-   ```
+## Steps
 
-2. **Understand the changes** - Look for:
-   - New operations
-   - Updated dependencies
-   - Node parameter changes
-   - Workflow capabilities
-   - Breaking changes
+1. Navigate to `n8n-repo/` directory
+2. Review the staged git changes to understand what's new or different
+3. Check `package.json` for the version number
+4. Write two output files:
+   - `/tmp/n8n-pr-title.txt` - A single-line PR title (no emojis)
+   - `/tmp/n8n-pr-body.md` - Full PR description in markdown
 
-3. **Write concise output files**:
-   - `/tmp/n8n-pr-title.txt` - One line title (no emojis)
-   - `/tmp/n8n-pr-body.md` - Markdown PR description
+## PR Description Requirements
 
-## Output Guidelines
+The PR body should include:
+- Brief summary of changes (1-2 sentences)
+- Version number from package.json
+- Source attribution: `**Source**: [MsgCore Backend](https://github.com/msgcore/msgcore)`
+- Specific changes found in the diff (new operations, parameter updates, dependency changes)
+- Workflow impact explanation if new features enable new automation patterns
+- Breaking changes section if applicable
+- Migration guide if breaking changes exist
 
-**Title** (`/tmp/n8n-pr-title.txt`):
+## Quality Guidelines
 
-- One line, descriptive, no emojis
-- Focus on the MAIN change
-- Examples: "Update n8n dependencies", "Add webhook operations", "Fix node parameters"
-
-**Body** (`/tmp/n8n-pr-body.md`):
-
-- Start with brief summary
-- List only ACTUAL changes from git diff
-- Include version info using $VERSION: `**Version**: v$VERSION`
-- Link to source backend: `**Source**: [MsgCore Backend](https://github.com/msgcore/msgcore)`
-- Keep it concise and direct
-
-## Structure (adapt as needed)
-
-```markdown
-## Summary
-
-[1-2 sentence description of what changed]
-
-**Version**: v$VERSION
-**Source**: [MsgCore Backend](https://github.com/msgcore/msgcore)
-
-### Changes
-
-[List actual changes - be specific and direct]
-
-- If new operations: list them with brief description
-- If dependency updates: list old→new versions
-- If breaking changes: explain clearly
-- If bug fixes: mention what was fixed
-
-### Workflow Impact (only if new features)
-
-[Describe how new features enable workflows]
-
-### Migration (only if breaking changes)
-
-[Instructions if needed]
-```
-
-## Important Rules
-
-✅ **DO**:
-
-- Be flexible - adapt structure to fit actual changes
-- Focus on what matters - skip sections if not applicable
-- Be direct and concise
-- Use actual operation names from git diff
-- Include only relevant information
-- Mention workflow impact if adding new features
-
-❌ **DON'T**:
-
-- Add sections that don't apply
-- Include placeholder text like "X operations generated" if not relevant
-- Add generic "improvements" that aren't real
-- Use rigid template when simple is better
-- Hallucinate operations
-- Always mention "300k+ users" (only if relevant context)
-
-## Environment Variables
-
-Available as shell environment variables (access with `$VARIABLE_NAME`):
-
-- `$VERSION` - Package version (e.g., "1.2.1")
-- `$COMMIT_SHA` - Commit hash (e.g., "a1b2c3d")
-- `$COMMIT_MSG` - Commit message
-- `$GITHUB_WORKSPACE` - Workspace directory
-
-**IMPORTANT**: Use these actual values in your output, not placeholder text!
+- Be accurate - only describe changes you see in the git diff
+- Be specific - use actual operation names, parameter names, version numbers
+- Be concise - focus on what matters to n8n workflow builders
+- Adapt the structure to fit the actual changes (skip sections that don't apply)
+- Explain workflow impact when relevant (how changes help users build automations)
+- No hallucinations - if you don't see it in the diff, don't mention it

--- a/.github/prompts/sdk-changelog.md
+++ b/.github/prompts/sdk-changelog.md
@@ -1,92 +1,34 @@
-# SDK Changelog Generation
+# Generate SDK Package PR Description
 
-Generate a PR description for the **@msgcore/sdk** package based on actual code changes.
+You are creating a pull request for the **@msgcore/sdk** package. The repository has been cloned to `sdk-repo/` and all changes are staged in git.
 
-## Your Task
+## Task
 
-1. **Analyze the git diff** to see what actually changed:
+Analyze what changed in this SDK update and write a pull request description that will help reviewers understand the changes.
 
-   ```bash
-   cd $GITHUB_WORKSPACE/sdk-repo
-   git diff --staged
-   ```
+## Steps
 
-2. **Understand the changes** - Look for:
-   - New methods/endpoints
-   - Updated dependencies
-   - Type changes
-   - Configuration updates
-   - Breaking changes
+1. Navigate to `sdk-repo/` directory
+2. Review the staged git changes to understand what's new or different
+3. Check `package.json` for the version number
+4. Write two output files:
+   - `/tmp/sdk-pr-title.txt` - A single-line PR title (no emojis)
+   - `/tmp/sdk-pr-body.md` - Full PR description in markdown
 
-3. **Write concise output files**:
-   - `/tmp/sdk-pr-title.txt` - One line title (no emojis)
-   - `/tmp/sdk-pr-body.md` - Markdown PR description
+## PR Description Requirements
 
-## Output Guidelines
+The PR body should include:
+- Brief summary of changes (1-2 sentences)
+- Version number from package.json
+- Source attribution: `**Source**: [MsgCore Backend](https://github.com/msgcore/msgcore)`
+- Specific changes found in the diff (new methods, type updates, dependency changes)
+- Breaking changes section if applicable
+- Migration guide if breaking changes exist
 
-**Title** (`/tmp/sdk-pr-title.txt`):
+## Quality Guidelines
 
-- One line, descriptive, no emojis
-- Focus on the MAIN change
-- Examples: "Update SDK dependencies", "Add webhook support", "Fix message delivery"
-
-**Body** (`/tmp/sdk-pr-body.md`):
-
-- Start with brief summary
-- List only ACTUAL changes from git diff
-- Include version info using $VERSION: `**Version**: v$VERSION`
-- Link to source backend: `**Source**: [MsgCore Backend](https://github.com/msgcore/msgcore)`
-- Keep it concise and direct
-
-## Structure (adapt as needed)
-
-```markdown
-## Summary
-
-[1-2 sentence description of what changed]
-
-**Version**: v$VERSION
-**Source**: [MsgCore Backend](https://github.com/msgcore/msgcore)
-
-### Changes
-
-[List actual changes - be specific and direct]
-
-- If new features: describe them
-- If dependency updates: list old→new versions
-- If breaking changes: explain clearly
-- If bug fixes: mention what was fixed
-
-### Migration (only if breaking changes)
-
-[Instructions if needed]
-```
-
-## Important Rules
-
-✅ **DO**:
-
-- Be flexible - adapt structure to fit actual changes
-- Focus on what matters - skip sections if not applicable
-- Be direct and concise
-- Use actual code/version numbers from git diff
-- Include only relevant information
-
-❌ **DON'T**:
-
-- Add sections that don't apply
-- Include placeholder text like "X contracts extracted" if not relevant
-- Add generic "improvements" that aren't real
-- Use rigid template when simple is better
-- Hallucinate features
-
-## Environment Variables
-
-Available as shell environment variables (access with `$VARIABLE_NAME`):
-
-- `$VERSION` - Package version (e.g., "1.2.1")
-- `$COMMIT_SHA` - Commit hash (e.g., "a1b2c3d")
-- `$COMMIT_MSG` - Commit message
-- `$GITHUB_WORKSPACE` - Workspace directory
-
-**IMPORTANT**: Use these actual values in your output, not placeholder text!
+- Be accurate - only describe changes you see in the git diff
+- Be specific - use actual method names, version numbers, file names
+- Be concise - focus on what matters to developers using this SDK
+- Adapt the structure to fit the actual changes (skip sections that don't apply)
+- No hallucinations - if you don't see it in the diff, don't mention it


### PR DESCRIPTION
## Summary

Fixes broken PR descriptions in the multi-repo publish workflow by removing shell variable syntax from changelog generation prompts.

## Problem

The workflow was creating PRs with incomplete descriptions like:
```
Version: v
Source: MsgCore Backend
```

This happened because the prompts used shell variables like `$VERSION` and `$GITHUB_WORKSPACE`, which weren't being substituted in the Claude Code execution context.

## Solution

Rewrote all changelog prompts following Claude Code best practices:

- **Clear task definitions** - Explicit context about what Claude is creating
- **Step-by-step instructions** - Numbered steps for Claude to follow
- **Direct discovery** - Claude reads version from package.json instead of variables
- **Quality guidelines** - Emphasize accuracy and specificity
- **No variable syntax** - Removed all `$VAR` references

## Changes

- `.github/prompts/sdk-changelog.md` - SDK package PR generation
- `.github/prompts/cli-changelog.md` - CLI package PR generation  
- `.github/prompts/n8n-changelog.md` - n8n package PR generation
- `.github/prompts/docker-changelog.md` - Docker release generation

## Testing

These changes will be tested in the next multi-repo publish workflow run. Claude Code will now:
1. Navigate to the cloned repo directory
2. Read the version directly from package.json
3. Analyze git diff to understand changes
4. Generate accurate PR descriptions with real version numbers

No code changes, only documentation prompts updated.