### PR TITLE
Fix docker publish workflow to handle existing tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -139,8 +139,18 @@ jobs:
 
       - name: Create and push git tag
         run: |
-          git tag -a "v${{ steps.version.outputs.version }}" -m "${{ steps.changelog_content.outputs.title }}"
-          git push origin "v${{ steps.version.outputs.version }}"
+          TAG_NAME="v${{ steps.version.outputs.version }}"
+
+          # Check if tag already exists
+          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+            echo "⚠️  Tag $TAG_NAME already exists, deleting and recreating..."
+            git tag -d "$TAG_NAME"
+            git push origin ":refs/tags/$TAG_NAME" 2>/dev/null || true
+          fi
+
+          # Create and push new tag
+          git tag -a "$TAG_NAME" -m "${{ steps.changelog_content.outputs.title }}"
+          git push origin "$TAG_NAME"
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## Summary

Fixes the Docker publish workflow failure when a git tag already exists.

## Problem

Workflow run failed with:
```
fatal: tag 'v1.0.1' already exists
Error: Process completed with exit code 128.
```

Link: https://github.com/msgcore/msgcore/actions/runs/18349558716

This happens when:
- Tags are created manually before running the workflow
- Re-running a failed workflow after the tag was already pushed
- Multiple workflow runs for the same version

## Solution

The workflow now checks if a tag exists before creating it:

1. **Check**: Uses `git rev-parse` to see if tag exists
2. **Delete**: If found, removes the tag locally and remotely
3. **Create**: Creates fresh tag with the current changelog message

This allows safe re-runs of the workflow without manual tag deletion.

## Changes

```diff
- name: Create and push git tag
  run: |
+   TAG_NAME="v${{ steps.version.outputs.version }}"
+
+   # Check if tag already exists
+   if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+     echo "⚠️  Tag $TAG_NAME already exists, deleting and recreating..."
+     git tag -d "$TAG_NAME"
+     git push origin ":refs/tags/$TAG_NAME" 2>/dev/null || true
+   fi
+
+   # Create and push new tag
-   git tag -a "v${{ steps.version.outputs.version }}" -m "..."
-   git push origin "v${{ steps.version.outputs.version }}"
+   git tag -a "$TAG_NAME" -m "${{ steps.changelog_content.outputs.title }}"
+   git push origin "$TAG_NAME"
```

## Testing

After merging, the workflow can be re-run even if v1.0.1 tag exists.