### PR TITLE
feat: simplify SendMessage API with target string format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "msgcore",
-  "version": "1.1.0",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "msgcore",
-      "version": "1.1.0",
+      "version": "1.1.3",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msgcore",
-  "version": "1.1.0",
+  "version": "1.1.3",
   "description": "Universal messaging gateway - single API for Discord, Telegram, WhatsApp, and more",
   "author": "MsgCore",
   "private": true,

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1817,128 +1817,6 @@ const CONTRACTS = [
     }
   },
   {
-    "controller": "BillingController",
-    "method": "createCheckout",
-    "httpMethod": "POST",
-    "path": "/api/v1/billing/checkout",
-    "contractMetadata": {
-      "command": "billing checkout",
-      "description": "Create Stripe checkout session for subscription upgrade",
-      "category": "Billing",
-      "requiredScopes": [],
-      "inputType": "CreateCheckoutDto",
-      "outputType": "CheckoutResponseDto",
-      "options": {
-        "tier": {
-          "required": true,
-          "description": "Subscription tier",
-          "choices": [
-            "STARTER",
-            "PRO",
-            "BUSINESS",
-            "ENTERPRISE"
-          ],
-          "type": "string"
-        },
-        "interval": {
-          "required": true,
-          "description": "Billing interval",
-          "choices": [
-            "monthly",
-            "annual"
-          ],
-          "type": "string"
-        }
-      },
-      "examples": [
-        {
-          "description": "Upgrade to PRO monthly",
-          "command": "msgcore billing checkout --tier PRO --interval monthly"
-        },
-        {
-          "description": "Upgrade to STARTER annually",
-          "command": "msgcore billing checkout --tier STARTER --interval annual"
-        }
-      ]
-    }
-  },
-  {
-    "controller": "BillingController",
-    "method": "createPortal",
-    "httpMethod": "POST",
-    "path": "/api/v1/billing/portal",
-    "contractMetadata": {
-      "command": "billing portal",
-      "description": "Access Stripe customer portal to manage subscription",
-      "category": "Billing",
-      "requiredScopes": [],
-      "outputType": "PortalResponseDto",
-      "examples": [
-        {
-          "description": "Open billing portal",
-          "command": "msgcore billing portal"
-        }
-      ]
-    }
-  },
-  {
-    "controller": "BillingController",
-    "method": "getSubscription",
-    "httpMethod": "GET",
-    "path": "/api/v1/billing/subscription",
-    "contractMetadata": {
-      "command": "billing subscription",
-      "description": "Get current subscription details including tier, status, and trial info",
-      "category": "Billing",
-      "requiredScopes": [],
-      "outputType": "SubscriptionResponseDto",
-      "examples": [
-        {
-          "description": "View subscription details",
-          "command": "msgcore billing subscription"
-        }
-      ]
-    }
-  },
-  {
-    "controller": "BillingController",
-    "method": "getUsage",
-    "httpMethod": "GET",
-    "path": "/api/v1/billing/usage",
-    "contractMetadata": {
-      "command": "billing usage",
-      "description": "Get usage statistics for projects, messages, platforms, webhooks with limit warnings",
-      "category": "Billing",
-      "requiredScopes": [],
-      "outputType": "UsageResponseDto",
-      "examples": [
-        {
-          "description": "View usage statistics",
-          "command": "msgcore billing usage"
-        }
-      ]
-    }
-  },
-  {
-    "controller": "BillingController",
-    "method": "syncSubscription",
-    "httpMethod": "POST",
-    "path": "/api/v1/billing/sync",
-    "contractMetadata": {
-      "command": "billing sync",
-      "description": "Manually sync subscription data from Stripe",
-      "category": "Billing",
-      "requiredScopes": [],
-      "outputType": "SyncResponseDto",
-      "examples": [
-        {
-          "description": "Sync subscription from Stripe",
-          "command": "msgcore billing sync"
-        }
-      ]
-    }
-  },
-  {
     "controller": "AuthController",
     "method": "signup",
     "httpMethod": "POST",
@@ -2242,182 +2120,123 @@ const CONTRACTS = [
     }
   },
   {
-    "controller": "PlatformLogsController",
-    "method": "listLogs",
-    "httpMethod": "GET",
-    "path": "/api/v1/projects/:project/platforms/logs",
+    "controller": "BillingController",
+    "method": "createCheckout",
+    "httpMethod": "POST",
+    "path": "/api/v1/billing/checkout",
     "contractMetadata": {
-      "command": "platforms logs list",
-      "description": "List platform processing logs for a project",
-      "category": "Platform Logs",
-      "requiredScopes": [
-        "platforms:read"
-      ],
-      "outputType": "PlatformLogsResponse",
-      "options": {
-        "platform": {
-          "description": "Filter by platform (telegram, discord)",
-          "type": "string"
-        },
-        "level": {
-          "description": "Filter by log level",
-          "choices": [
-            "info",
-            "warn",
-            "error",
-            "debug"
-          ],
-          "type": "string"
-        },
-        "category": {
-          "description": "Filter by log category",
-          "choices": [
-            "connection",
-            "webhook",
-            "message",
-            "error",
-            "auth",
-            "general"
-          ],
-          "type": "string"
-        },
-        "startDate": {
-          "description": "Filter logs after this date (ISO 8601)",
-          "type": "string"
-        },
-        "endDate": {
-          "description": "Filter logs before this date (ISO 8601)",
-          "type": "string"
-        },
-        "limit": {
-          "description": "Number of logs to return (1-1000)",
-          "type": "number",
-          "default": "100"
-        },
-        "offset": {
-          "description": "Number of logs to skip",
-          "type": "number"
-        }
-      },
-      "examples": [
-        {
-          "description": "List recent platform logs",
-          "command": "msgcore platforms logs list my-project"
-        },
-        {
-          "description": "List only error logs",
-          "command": "msgcore platforms logs list my-project --level error"
-        },
-        {
-          "description": "List webhook logs for Telegram",
-          "command": "msgcore platforms logs list my-project --platform telegram --category webhook"
-        }
-      ]
-    }
-  },
-  {
-    "controller": "PlatformLogsController",
-    "method": "getPlatformLogs",
-    "httpMethod": "GET",
-    "path": "/api/v1/projects/:project/platforms/:platformId/logs",
-    "contractMetadata": {
-      "command": "platforms logs get",
-      "description": "List logs for a specific platform configuration",
-      "category": "Platform Logs",
-      "requiredScopes": [
-        "platforms:read"
-      ],
-      "outputType": "PlatformLogsResponse",
-      "options": {
-        "level": {
-          "description": "Filter by log level",
-          "choices": [
-            "info",
-            "warn",
-            "error",
-            "debug"
-          ],
-          "type": "string"
-        },
-        "category": {
-          "description": "Filter by log category",
-          "choices": [
-            "connection",
-            "webhook",
-            "message",
-            "error",
-            "auth",
-            "general"
-          ],
-          "type": "string"
-        },
-        "startDate": {
-          "description": "Filter logs after this date (ISO 8601)",
-          "type": "string"
-        },
-        "endDate": {
-          "description": "Filter logs before this date (ISO 8601)",
-          "type": "string"
-        },
-        "limit": {
-          "description": "Number of logs to return (1-1000)",
-          "type": "number",
-          "default": "100"
-        },
-        "offset": {
-          "description": "Number of logs to skip",
-          "type": "number"
-        }
-      },
-      "examples": [
-        {
-          "description": "List logs for specific platform",
-          "command": "msgcore platforms logs get my-project platform-id-123"
-        },
-        {
-          "description": "List recent errors for platform",
-          "command": "msgcore platforms logs get my-project platform-id-123 --level error --limit 50"
-        }
-      ]
-    }
-  },
-  {
-    "controller": "PlatformLogsController",
-    "method": "getLogStats",
-    "httpMethod": "GET",
-    "path": "/api/v1/projects/:project/platforms/logs/stats",
-    "contractMetadata": {
-      "command": "platforms logs stats",
-      "description": "Get platform logs statistics and recent errors",
-      "category": "Platform Logs",
-      "requiredScopes": [
-        "platforms:read"
-      ],
-      "outputType": "PlatformLogStatsResponse",
-      "examples": [
-        {
-          "description": "Get platform logs statistics",
-          "command": "msgcore platforms logs stats my-project"
-        }
-      ]
-    }
-  },
-  {
-    "controller": "PlatformHealthController",
-    "method": "getSupportedPlatforms",
-    "httpMethod": "GET",
-    "path": "/api/v1/platforms/supported",
-    "contractMetadata": {
-      "command": "platforms supported",
-      "description": "List supported platforms with credential requirements",
-      "category": "Platforms",
+      "command": "billing checkout",
+      "description": "Create Stripe checkout session for subscription upgrade",
+      "category": "Billing",
       "requiredScopes": [],
-      "excludeFromMcp": true,
-      "outputType": "SupportedPlatformsResponse",
+      "inputType": "CreateCheckoutDto",
+      "outputType": "CheckoutResponseDto",
+      "options": {
+        "tier": {
+          "required": true,
+          "description": "Subscription tier",
+          "choices": [
+            "STARTER",
+            "PRO",
+            "BUSINESS",
+            "ENTERPRISE"
+          ],
+          "type": "string"
+        },
+        "interval": {
+          "required": true,
+          "description": "Billing interval",
+          "choices": [
+            "monthly",
+            "annual"
+          ],
+          "type": "string"
+        }
+      },
       "examples": [
         {
-          "description": "List supported platforms",
-          "command": "msgcore platforms supported"
+          "description": "Upgrade to PRO monthly",
+          "command": "msgcore billing checkout --tier PRO --interval monthly"
+        },
+        {
+          "description": "Upgrade to STARTER annually",
+          "command": "msgcore billing checkout --tier STARTER --interval annual"
+        }
+      ]
+    }
+  },
+  {
+    "controller": "BillingController",
+    "method": "createPortal",
+    "httpMethod": "POST",
+    "path": "/api/v1/billing/portal",
+    "contractMetadata": {
+      "command": "billing portal",
+      "description": "Access Stripe customer portal to manage subscription",
+      "category": "Billing",
+      "requiredScopes": [],
+      "outputType": "PortalResponseDto",
+      "examples": [
+        {
+          "description": "Open billing portal",
+          "command": "msgcore billing portal"
+        }
+      ]
+    }
+  },
+  {
+    "controller": "BillingController",
+    "method": "getSubscription",
+    "httpMethod": "GET",
+    "path": "/api/v1/billing/subscription",
+    "contractMetadata": {
+      "command": "billing subscription",
+      "description": "Get current subscription details including tier, status, and trial info",
+      "category": "Billing",
+      "requiredScopes": [],
+      "outputType": "SubscriptionResponseDto",
+      "examples": [
+        {
+          "description": "View subscription details",
+          "command": "msgcore billing subscription"
+        }
+      ]
+    }
+  },
+  {
+    "controller": "BillingController",
+    "method": "getUsage",
+    "httpMethod": "GET",
+    "path": "/api/v1/billing/usage",
+    "contractMetadata": {
+      "command": "billing usage",
+      "description": "Get usage statistics for projects, messages, platforms, webhooks with limit warnings",
+      "category": "Billing",
+      "requiredScopes": [],
+      "outputType": "UsageResponseDto",
+      "examples": [
+        {
+          "description": "View usage statistics",
+          "command": "msgcore billing usage"
+        }
+      ]
+    }
+  },
+  {
+    "controller": "BillingController",
+    "method": "syncSubscription",
+    "httpMethod": "POST",
+    "path": "/api/v1/billing/sync",
+    "contractMetadata": {
+      "command": "billing sync",
+      "description": "Manually sync subscription data from Stripe",
+      "category": "Billing",
+      "requiredScopes": [],
+      "outputType": "SyncResponseDto",
+      "examples": [
+        {
+          "description": "Sync subscription from Stripe",
+          "command": "msgcore billing sync"
         }
       ]
     }
@@ -2601,6 +2420,187 @@ const CONTRACTS = [
           "default": 100
         }
       }
+    }
+  },
+  {
+    "controller": "PlatformLogsController",
+    "method": "listLogs",
+    "httpMethod": "GET",
+    "path": "/api/v1/projects/:project/platforms/logs",
+    "contractMetadata": {
+      "command": "platforms logs list",
+      "description": "List platform processing logs for a project",
+      "category": "Platform Logs",
+      "requiredScopes": [
+        "platforms:read"
+      ],
+      "outputType": "PlatformLogsResponse",
+      "options": {
+        "platform": {
+          "description": "Filter by platform (telegram, discord)",
+          "type": "string"
+        },
+        "level": {
+          "description": "Filter by log level",
+          "choices": [
+            "info",
+            "warn",
+            "error",
+            "debug"
+          ],
+          "type": "string"
+        },
+        "category": {
+          "description": "Filter by log category",
+          "choices": [
+            "connection",
+            "webhook",
+            "message",
+            "error",
+            "auth",
+            "general"
+          ],
+          "type": "string"
+        },
+        "startDate": {
+          "description": "Filter logs after this date (ISO 8601)",
+          "type": "string"
+        },
+        "endDate": {
+          "description": "Filter logs before this date (ISO 8601)",
+          "type": "string"
+        },
+        "limit": {
+          "description": "Number of logs to return (1-1000)",
+          "type": "number",
+          "default": "100"
+        },
+        "offset": {
+          "description": "Number of logs to skip",
+          "type": "number"
+        }
+      },
+      "examples": [
+        {
+          "description": "List recent platform logs",
+          "command": "msgcore platforms logs list my-project"
+        },
+        {
+          "description": "List only error logs",
+          "command": "msgcore platforms logs list my-project --level error"
+        },
+        {
+          "description": "List webhook logs for Telegram",
+          "command": "msgcore platforms logs list my-project --platform telegram --category webhook"
+        }
+      ]
+    }
+  },
+  {
+    "controller": "PlatformLogsController",
+    "method": "getPlatformLogs",
+    "httpMethod": "GET",
+    "path": "/api/v1/projects/:project/platforms/:platformId/logs",
+    "contractMetadata": {
+      "command": "platforms logs get",
+      "description": "List logs for a specific platform configuration",
+      "category": "Platform Logs",
+      "requiredScopes": [
+        "platforms:read"
+      ],
+      "outputType": "PlatformLogsResponse",
+      "options": {
+        "level": {
+          "description": "Filter by log level",
+          "choices": [
+            "info",
+            "warn",
+            "error",
+            "debug"
+          ],
+          "type": "string"
+        },
+        "category": {
+          "description": "Filter by log category",
+          "choices": [
+            "connection",
+            "webhook",
+            "message",
+            "error",
+            "auth",
+            "general"
+          ],
+          "type": "string"
+        },
+        "startDate": {
+          "description": "Filter logs after this date (ISO 8601)",
+          "type": "string"
+        },
+        "endDate": {
+          "description": "Filter logs before this date (ISO 8601)",
+          "type": "string"
+        },
+        "limit": {
+          "description": "Number of logs to return (1-1000)",
+          "type": "number",
+          "default": "100"
+        },
+        "offset": {
+          "description": "Number of logs to skip",
+          "type": "number"
+        }
+      },
+      "examples": [
+        {
+          "description": "List logs for specific platform",
+          "command": "msgcore platforms logs get my-project platform-id-123"
+        },
+        {
+          "description": "List recent errors for platform",
+          "command": "msgcore platforms logs get my-project platform-id-123 --level error --limit 50"
+        }
+      ]
+    }
+  },
+  {
+    "controller": "PlatformLogsController",
+    "method": "getLogStats",
+    "httpMethod": "GET",
+    "path": "/api/v1/projects/:project/platforms/logs/stats",
+    "contractMetadata": {
+      "command": "platforms logs stats",
+      "description": "Get platform logs statistics and recent errors",
+      "category": "Platform Logs",
+      "requiredScopes": [
+        "platforms:read"
+      ],
+      "outputType": "PlatformLogStatsResponse",
+      "examples": [
+        {
+          "description": "Get platform logs statistics",
+          "command": "msgcore platforms logs stats my-project"
+        }
+      ]
+    }
+  },
+  {
+    "controller": "PlatformHealthController",
+    "method": "getSupportedPlatforms",
+    "httpMethod": "GET",
+    "path": "/api/v1/platforms/supported",
+    "contractMetadata": {
+      "command": "platforms supported",
+      "description": "List supported platforms with credential requirements",
+      "category": "Platforms",
+      "requiredScopes": [],
+      "excludeFromMcp": true,
+      "outputType": "SupportedPlatformsResponse",
+      "examples": [
+        {
+          "description": "List supported platforms",
+          "command": "msgcore platforms supported"
+        }
+      ]
     }
   },
   {

--- a/packages/contracts/contracts.json
+++ b/packages/contracts/contracts.json
@@ -115,7 +115,7 @@
       "ReceivedMessageResponse": "export interface ReceivedMessageResponse {\n  id: string;\n  platform: string;\n  providerMessageId: string;\n  providerChatId: string;\n  providerUserId: string;\n  userDisplay: string | null;\n  messageText: string | null;\n  messageType: string;\n  timestamp: Date;\n  direction: string;\n  source: string;\n  rawData: any;\n  platformConfig?: {\n    id: string;\n    platform: string;\n    isActive: boolean;\n    testMode: boolean;\n  };\n}",
       "ReceivedReactionResponse": "export interface ReceivedReactionResponse {\n  id: string;\n  projectId: string;\n  platformId: string;\n  platform: string;\n  providerMessageId: string;\n  providerChatId: string;\n  providerUserId: string;\n  userDisplay: string | null;\n  emoji: string;\n  reactionType: 'added' | 'removed';\n  rawData: Record<string, any>;\n  timestamp: Date;\n}",
       "ResourceUsage": "export interface ResourceUsage {\n  current: number;\n  limit: number;\n  usagePercent: number;\n  isApproachingLimit: boolean;\n  isAtLimit: boolean;\n  nextTier?: string;\n}",
-      "SendMessageDto": "export interface SendMessageDto {\n  targets: TargetDto[];\n  content: ContentDto;\n  options?: OptionsDto;\n  metadata?: MetadataDto;\n}",
+      "SendMessageDto": "export interface SendMessageDto {\n  target: string;\n  text?: string;\n  content?: ContentDto;\n  options?: OptionsDto;\n  metadata?: MetadataDto;\n}",
       "SendReactionDto": "export interface SendReactionDto {\n  platformId: string;\n  messageId: string;\n  emoji: string;\n}",
       "SignupDto": "export interface SignupDto {\n  email: string;\n  password: string;\n  name?: string;\n}",
       "SubscriptionResponseDto": "export interface SubscriptionResponseDto {\n  tier: SubscriptionTier;\n  status: SubscriptionStatus;\n  startedAt: Date | null;\n  endsAt: Date | null;\n  stripeCustomerId: string | null;\n  stripeSubscriptionId: string | null;\n  isTrialing: boolean;\n  daysUntilEnd: number | null;\n}",
@@ -124,8 +124,6 @@
       "SupportedPlatformsResponse": "export interface SupportedPlatformsResponse {\n  platforms: Array<{\n    name: string;\n    displayName: string;\n    connectionType: string;\n    features: {\n      supportsWebhooks: boolean;\n      supportsPolling: boolean;\n      supportsWebSocket: boolean;\n    };\n    capabilities: Array<{\n      capability: string;\n      limitations?: string;\n    }>;\n    credentials: {\n      required: string[];\n      optional: string[];\n      example: Record<string, any>;\n    } | null;\n  }>;\n}",
       "SyncHistoryDto": "export interface SyncHistoryDto {\n  platformId?: string;\n  startDate?: string;\n  endDate?: string;\n  limit?: number;\n}",
       "SyncResponseDto": "export interface SyncResponseDto {\n  synced: boolean;\n}",
-      "TargetDto": "export interface TargetDto {\n  platformId: string;\n  type: TargetType;\n  id: string;\n}",
-      "TargetType": "export type TargetType = 'chat' | 'identity' | 'messages' | 'date_range';",
       "UpdateAnalysisProfileDto": "export interface UpdateAnalysisProfileDto {\n  name?: string;\n  description?: string;\n  graphDefinition?: Record<string, any>;\n  entitySchemaIds?: string[];\n  storeEntities?: boolean;\n  generateTags?: boolean;\n}",
       "UpdateChatDto": "export interface UpdateChatDto {\n  name?: string;\n  avatarUrl?: string;\n  metadata?: any;\n}",
       "UpdateEntitySchemaDto": "export interface UpdateEntitySchemaDto {\n  name?: string;\n  description?: string;\n  extractionType?: 'llm_extraction' | 'rule_based' | 'api_logged';\n  properties?: Record<string, any>;\n  prompt?: string;\n  model?: string;\n  temperature?: number;\n  ruleDefinition?: Record<string, any>;\n}",
@@ -1052,27 +1050,24 @@
       "outputType": "MessageSendResponse",
       "options": {
         "target": {
-          "description": "Single target in format: platformId:type:id",
-          "type": "target_pattern"
-        },
-        "targets": {
-          "description": "Multiple targets comma-separated: platformId:type:id,platformId:type:id",
-          "type": "targets_pattern"
+          "required": true,
+          "description": "Target(s) in format platformId:type:id. For multiple, comma-separate: p1:user:1,p2:channel:2",
+          "type": "string"
         },
         "text": {
           "description": "Message text content",
           "type": "string"
         },
         "content": {
-          "description": "Full message content object (advanced)",
+          "description": "Full content object (text, markdown, html, attachments, buttons, embeds)",
           "type": "object"
         },
         "options": {
-          "description": "Message options",
+          "description": "Message options (replyTo, silent, scheduled)",
           "type": "object"
         },
         "metadata": {
-          "description": "Message metadata",
+          "description": "Message metadata (trackingId, tags, priority)",
           "type": "object"
         }
       },
@@ -1083,7 +1078,7 @@
         },
         {
           "description": "Send to multiple targets",
-          "command": "msgcore messages send --targets \"platform1:user:123,platform2:channel:456\" --text \"Broadcast message\""
+          "command": "msgcore messages send --target \"platform1:user:123,platform2:channel:456\" --text \"Broadcast message\""
         },
         {
           "description": "Advanced with full content object",
@@ -1930,6 +1925,121 @@
     }
   },
   {
+    "controller": "ApiKeysController",
+    "method": "create",
+    "httpMethod": "POST",
+    "path": "/api/v1/projects/:project/keys",
+    "contractMetadata": {
+      "command": "keys create",
+      "description": "Generate a new API key",
+      "category": "ApiKeys",
+      "requiredScopes": [
+        "keys:write"
+      ],
+      "inputType": "CreateApiKeyDto",
+      "outputType": "ApiKeyResponse",
+      "options": {
+        "name": {
+          "required": true,
+          "description": "API key name",
+          "type": "string"
+        },
+        "scopes": {
+          "required": true,
+          "description": "Array of scope strings (e.g., [\"messages:read\", \"messages:write\"])",
+          "type": "array"
+        },
+        "expiresInDays": {
+          "description": "Expiration in days",
+          "type": "number"
+        }
+      },
+      "examples": [
+        {
+          "description": "Create messaging API key",
+          "command": "msgcore keys create --name \"Bot Key\" --scopes \"messages:send,messages:read\""
+        }
+      ]
+    }
+  },
+  {
+    "controller": "ApiKeysController",
+    "method": "findAll",
+    "httpMethod": "GET",
+    "path": "/api/v1/projects/:project/keys",
+    "contractMetadata": {
+      "command": "keys list",
+      "description": "List all API keys for project",
+      "category": "ApiKeys",
+      "requiredScopes": [
+        "keys:read"
+      ],
+      "outputType": "ApiKeyListResponse[]",
+      "examples": [
+        {
+          "description": "List all API keys",
+          "command": "msgcore keys list"
+        }
+      ]
+    }
+  },
+  {
+    "controller": "ApiKeysController",
+    "method": "revoke",
+    "httpMethod": "DELETE",
+    "path": "/api/v1/projects/:project/keys/:keyId",
+    "contractMetadata": {
+      "command": "keys revoke",
+      "description": "Revoke an API key",
+      "category": "ApiKeys",
+      "requiredScopes": [
+        "keys:write"
+      ],
+      "outputType": "MessageResponse",
+      "options": {
+        "keyId": {
+          "required": true,
+          "description": "API key ID to revoke",
+          "type": "string"
+        }
+      },
+      "examples": [
+        {
+          "description": "Revoke an API key",
+          "command": "msgcore keys revoke --keyId \"key-123\""
+        }
+      ]
+    }
+  },
+  {
+    "controller": "ApiKeysController",
+    "method": "roll",
+    "httpMethod": "POST",
+    "path": "/api/v1/projects/:project/keys/:keyId/roll",
+    "contractMetadata": {
+      "command": "keys roll",
+      "description": "Roll an API key (generate new key, revoke old after 24h)",
+      "category": "ApiKeys",
+      "requiredScopes": [
+        "keys:write"
+      ],
+      "outputType": "ApiKeyRollResponse",
+      "options": {
+        "keyId": {
+          "required": true,
+          "description": "API key ID to roll",
+          "type": "string"
+        }
+      },
+      "examples": [
+        {
+          "description": "Roll an API key",
+          "command": "msgcore keys roll --keyId \"key-123\""
+        }
+      ]
+    }
+  },
+  {
     "controller": "AuthController",
     "method": "signup",
     "httpMethod": "POST",
@@ -2113,121 +2223,6 @@
         {
           "description": "Update your name",
           "command": "msgcore auth update-profile --name \"John Doe\""
-        }
-      ]
-    }
-  },
-  {
-    "controller": "ApiKeysController",
-    "method": "create",
-    "httpMethod": "POST",
-    "path": "/api/v1/projects/:project/keys",
-    "contractMetadata": {
-      "command": "keys create",
-      "description": "Generate a new API key",
-      "category": "ApiKeys",
-      "requiredScopes": [
-        "keys:write"
-      ],
-      "inputType": "CreateApiKeyDto",
-      "outputType": "ApiKeyResponse",
-      "options": {
-        "name": {
-          "required": true,
-          "description": "API key name",
-          "type": "string"
-        },
-        "scopes": {
-          "required": true,
-          "description": "Array of scope strings (e.g., [\"messages:read\", \"messages:write\"])",
-          "type": "array"
-        },
-        "expiresInDays": {
-          "description": "Expiration in days",
-          "type": "number"
-        }
-      },
-      "examples": [
-        {
-          "description": "Create messaging API key",
-          "command": "msgcore keys create --name \"Bot Key\" --scopes \"messages:send,messages:read\""
-        }
-      ]
-    }
-  },
-  {
-    "controller": "ApiKeysController",
-    "method": "findAll",
-    "httpMethod": "GET",
-    "path": "/api/v1/projects/:project/keys",
-    "contractMetadata": {
-      "command": "keys list",
-      "description": "List all API keys for project",
-      "category": "ApiKeys",
-      "requiredScopes": [
-        "keys:read"
-      ],
-      "outputType": "ApiKeyListResponse[]",
-      "examples": [
-        {
-          "description": "List all API keys",
-          "command": "msgcore keys list"
-        }
-      ]
-    }
-  },
-  {
-    "controller": "ApiKeysController",
-    "method": "revoke",
-    "httpMethod": "DELETE",
-    "path": "/api/v1/projects/:project/keys/:keyId",
-    "contractMetadata": {
-      "command": "keys revoke",
-      "description": "Revoke an API key",
-      "category": "ApiKeys",
-      "requiredScopes": [
-        "keys:write"
-      ],
-      "outputType": "MessageResponse",
-      "options": {
-        "keyId": {
-          "required": true,
-          "description": "API key ID to revoke",
-          "type": "string"
-        }
-      },
-      "examples": [
-        {
-          "description": "Revoke an API key",
-          "command": "msgcore keys revoke --keyId \"key-123\""
-        }
-      ]
-    }
-  },
-  {
-    "controller": "ApiKeysController",
-    "method": "roll",
-    "httpMethod": "POST",
-    "path": "/api/v1/projects/:project/keys/:keyId/roll",
-    "contractMetadata": {
-      "command": "keys roll",
-      "description": "Roll an API key (generate new key, revoke old after 24h)",
-      "category": "ApiKeys",
-      "requiredScopes": [
-        "keys:write"
-      ],
-      "outputType": "ApiKeyRollResponse",
-      "options": {
-        "keyId": {
-          "required": true,
-          "description": "API key ID to roll",
-          "type": "string"
-        }
-      },
-      "examples": [
-        {
-          "description": "Roll an API key",
-          "command": "msgcore keys roll --keyId \"key-123\""
         }
       ]
     }

--- a/packages/contracts/extraction-summary.json
+++ b/packages/contracts/extraction-summary.json
@@ -1,5 +1,5 @@
 {
-  "extractedAt": "2025-11-30T15:06:26.474Z",
+  "extractedAt": "2025-12-29T14:27:47.211Z",
   "totalContracts": 87,
   "contractsByController": {
     "WebhooksController": 6,
@@ -9,8 +9,8 @@
     "MembersController": 5,
     "IdentitiesController": 12,
     "BillingController": 5,
-    "AuthController": 6,
     "ApiKeysController": 4,
+    "AuthController": 6,
     "PlatformLogsController": 3,
     "PlatformHealthController": 1,
     "ChatsController": 6,
@@ -28,8 +28,8 @@
     "Members": 5,
     "Identities": 12,
     "Billing": 5,
-    "Auth": 6,
     "ApiKeys": 4,
+    "Auth": 6,
     "Platform Logs": 3,
     "Chats": 6,
     "Analysis / Models": 1,

--- a/packages/n8n/README.md
+++ b/packages/n8n/README.md
@@ -106,6 +106,13 @@ npm install n8n-nodes-msgcore
 - **billing usage** - Get usage statistics for projects, messages, platforms, webhooks with limit warnings
 - **billing sync** - Manually sync subscription data from Stripe
 
+### ApiKeys
+
+- **keys create** - Generate a new API key
+- **keys list** - List all API keys for project
+- **keys revoke** - Revoke an API key
+- **keys roll** - Roll an API key (generate new key, revoke old after 24h)
+
 ### Auth
 
 - **auth signup** - Create a new user account (first user becomes admin)
@@ -114,13 +121,6 @@ npm install n8n-nodes-msgcore
 - **auth whoami** - Get current authentication context and permissions
 - **auth update-password** - Update your password (requires current password)
 - **auth update-profile** - Update your profile information
-
-### ApiKeys
-
-- **keys create** - Generate a new API key
-- **keys list** - List all API keys for project
-- **keys revoke** - Revoke an API key
-- **keys roll** - Roll an API key (generate new key, revoke old after 24h)
 
 ### Platform Logs
 

--- a/packages/n8n/nodes/MsgCore/MsgCore.node.ts
+++ b/packages/n8n/nodes/MsgCore/MsgCore.node.ts
@@ -128,7 +128,7 @@ export class MsgCore implements INodeType {
           type: 'string',
           required: true,
           default: '',
-          description: 'id parameter',
+          description: 'Id parameter',
           displayOptions: {
             show: {
               resource: ['analysis / entities'],
@@ -257,29 +257,8 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'name': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Profile description',
-            name: 'description',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['analysis / profiles'],
-                operation: ['profiles'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'description': '={{$value}}',
                 },
               },
             },
@@ -320,67 +299,85 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'entitySchemaIds': '={{$value}}',
                 },
               },
             },
           },
       {
-            displayName: 'Store extracted entities',
-            name: 'storeEntities',
-            type: 'boolean',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['analysis / profiles'],
-                operation: ['profiles'],
-              },
+          displayName: 'Project',
+          name: 'project',
+          type: 'string',
+          required: true,
+          default: 'default',
+          description: 'Project identifier to operate on',
+          displayOptions: {
+            show: {
+              resource: ['analysis / profiles'],
+              operation: ['profiles'],
             },
-            routing: {
-              request: {
-                qs: {
-                  'storeEntities': '={{$value}}',
+          },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['analysis / profiles'],
+              operation: ['profiles'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Profile description',
+              name: 'description',
+              type: 'string',
+              default: "",
+              description: 'Profile description',
+              
+              routing: {
+                request: {
+                  body: {
+                    'description': '={{$value}}',
+                  },
                 },
               },
             },
-          },
-      {
-            displayName: 'Generate tags from analysis',
-            name: 'generateTags',
-            type: 'boolean',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['analysis / profiles'],
-                operation: ['profiles'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'generateTags': '={{$value}}',
+            {
+              displayName: 'Store extracted entities',
+              name: 'storeEntities',
+              type: 'boolean',
+              default: "",
+              description: 'Store extracted entities',
+              
+              routing: {
+                request: {
+                  body: {
+                    'storeEntities': '={{$value}}',
+                  },
                 },
               },
             },
-          },
-      {
-          displayName: 'Project',
-          name: 'project',
-          type: 'string',
-          required: true,
-          default: 'default',
-          description: 'Project identifier to operate on',
-          displayOptions: {
-            show: {
-              resource: ['analysis / profiles'],
-              operation: ['profiles'],
-            },
-          },
+            {
+              displayName: 'Generate tags from analysis',
+              name: 'generateTags',
+              type: 'boolean',
+              default: "",
+              description: 'Generate tags from analysis',
+              
+              routing: {
+                request: {
+                  body: {
+                    'generateTags': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
           displayName: 'Project',
@@ -411,12 +408,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'ProfileId',
+          displayName: 'Profile Id',
           name: 'profileId',
           type: 'string',
           required: true,
           default: '',
-          description: 'profileId parameter',
+          description: 'Profile Id parameter',
           displayOptions: {
             show: {
               resource: ['analysis / profiles'],
@@ -439,12 +436,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'ProfileId',
+          displayName: 'Profile Id',
           name: 'profileId',
           type: 'string',
           required: true,
           default: '',
-          description: 'profileId parameter',
+          description: 'Profile Id parameter',
           displayOptions: {
             show: {
               resource: ['analysis / profiles'],
@@ -467,12 +464,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'ProfileId',
+          displayName: 'Profile Id',
           name: 'profileId',
           type: 'string',
           required: true,
           default: '',
-          description: 'profileId parameter',
+          description: 'Profile Id parameter',
           displayOptions: {
             show: {
               resource: ['analysis / profiles'],
@@ -574,97 +571,13 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'profileId': '={{$value}}',
                 },
               },
             },
           },
       {
-            displayName: 'Filter by chat IDs (JSON array)',
-            name: 'chatIds',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['analysis / runs'],
-                operation: ['runs'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'chatIds': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Filter by identity IDs (JSON array)',
-            name: 'identityIds',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['analysis / runs'],
-                operation: ['runs'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'identityIds': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Start date for analysis (ISO 8601)',
-            name: 'dateRangeStart',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['analysis / runs'],
-                operation: ['runs'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'dateRangeStart': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'End date for analysis (ISO 8601)',
-            name: 'dateRangeEnd',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['analysis / runs'],
-                operation: ['runs'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'dateRangeEnd': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
           displayName: 'Project',
           name: 'project',
           type: 'string',
@@ -677,6 +590,81 @@ export class MsgCore implements INodeType {
               operation: ['runs'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['analysis / runs'],
+              operation: ['runs'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Filter by chat IDs (JSON array)',
+              name: 'chatIds',
+              type: 'string',
+              default: "",
+              description: 'Filter by chat IDs (JSON array)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'chatIds': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Filter by identity IDs (JSON array)',
+              name: 'identityIds',
+              type: 'string',
+              default: "",
+              description: 'Filter by identity IDs (JSON array)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'identityIds': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Start date for analysis (ISO 8601)',
+              name: 'dateRangeStart',
+              type: 'string',
+              default: "",
+              description: 'Start date for analysis (ISO 8601)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'dateRangeStart': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'End date for analysis (ISO 8601)',
+              name: 'dateRangeEnd',
+              type: 'string',
+              default: "",
+              description: 'End date for analysis (ISO 8601)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'dateRangeEnd': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
           displayName: 'Project',
@@ -721,12 +709,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'RunId',
+          displayName: 'Run Id',
           name: 'runId',
           type: 'string',
           required: true,
           default: '',
-          description: 'runId parameter',
+          description: 'Run Id parameter',
           displayOptions: {
             show: {
               resource: ['analysis / runs'],
@@ -749,12 +737,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'RunId',
+          displayName: 'Run Id',
           name: 'runId',
           type: 'string',
           required: true,
           default: '',
-          description: 'runId parameter',
+          description: 'Run Id parameter',
           displayOptions: {
             show: {
               resource: ['analysis / runs'],
@@ -856,7 +844,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'project': '={{$value}}',
                 },
               },
@@ -877,7 +865,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'name': '={{$value}}',
                 },
               },
@@ -898,7 +886,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'extractionType': '={{$value}}',
                 },
               },
@@ -919,55 +907,13 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'properties': '={{$value}}',
                 },
               },
             },
           },
       {
-            displayName: 'LLM prompt (for llm_extraction)',
-            name: 'prompt',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['analysis / schemas'],
-                operation: ['schemas'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'prompt': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Schema description',
-            name: 'description',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['analysis / schemas'],
-                operation: ['schemas'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'description': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
           displayName: 'Project',
           name: 'project',
           type: 'string',
@@ -980,6 +926,51 @@ export class MsgCore implements INodeType {
               operation: ['schemas'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['analysis / schemas'],
+              operation: ['schemas'],
+            },
+          },
+          options: [
+            {
+              displayName: 'LLM prompt (for llm_extraction)',
+              name: 'prompt',
+              type: 'string',
+              default: "",
+              description: 'LLM prompt (for llm_extraction)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'prompt': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Schema description',
+              name: 'description',
+              type: 'string',
+              default: "",
+              description: 'Schema description',
+              
+              routing: {
+                request: {
+                  body: {
+                    'description': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
             displayName: 'Project ID',
@@ -1073,18 +1064,133 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'SchemaId',
+          displayName: 'Schema Id',
           name: 'schemaId',
           type: 'string',
           required: true,
           default: '',
-          description: 'schemaId parameter',
+          description: 'Schema Id parameter',
           displayOptions: {
             show: {
               resource: ['analysis / schemas'],
               operation: ['schemas'],
             },
           },
+        },
+      {
+            displayName: 'Project ID',
+            name: 'project',
+            type: 'string',
+            required: true,
+            default: "",
+            
+            displayOptions: {
+              show: {
+                resource: ['analysis / schemas'],
+                operation: ['schemas'],
+              },
+            },
+            routing: {
+              request: {
+                body: {
+                  'project': '={{$value}}',
+                },
+              },
+            },
+          },
+      {
+            displayName: 'Schema ID',
+            name: 'schemaId',
+            type: 'string',
+            required: true,
+            default: "",
+            
+            displayOptions: {
+              show: {
+                resource: ['analysis / schemas'],
+                operation: ['schemas'],
+              },
+            },
+            routing: {
+              request: {
+                body: {
+                  'schemaId': '={{$value}}',
+                },
+              },
+            },
+          },
+      {
+          displayName: 'Project',
+          name: 'project',
+          type: 'string',
+          required: true,
+          default: 'default',
+          description: 'Project identifier to operate on',
+          displayOptions: {
+            show: {
+              resource: ['analysis / schemas'],
+              operation: ['schemas'],
+            },
+          },
+        },
+      {
+          displayName: 'Schema Id',
+          name: 'schemaId',
+          type: 'string',
+          required: true,
+          default: '',
+          description: 'Schema Id parameter',
+          displayOptions: {
+            show: {
+              resource: ['analysis / schemas'],
+              operation: ['schemas'],
+            },
+          },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['analysis / schemas'],
+              operation: ['schemas'],
+            },
+          },
+          options: [
+            {
+              displayName: 'New schema name',
+              name: 'name',
+              type: 'string',
+              default: "",
+              description: 'New schema name',
+              
+              routing: {
+                request: {
+                  body: {
+                    'name': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'New LLM prompt',
+              name: 'prompt',
+              type: 'string',
+              default: "",
+              description: 'New LLM prompt',
+              
+              routing: {
+                request: {
+                  body: {
+                    'prompt': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
             displayName: 'Project ID',
@@ -1129,48 +1235,6 @@ export class MsgCore implements INodeType {
             },
           },
       {
-            displayName: 'New schema name',
-            name: 'name',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['analysis / schemas'],
-                operation: ['schemas'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'name': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'New LLM prompt',
-            name: 'prompt',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['analysis / schemas'],
-                operation: ['schemas'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'prompt': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
           displayName: 'Project',
           name: 'project',
           type: 'string',
@@ -1185,82 +1249,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'SchemaId',
+          displayName: 'Schema Id',
           name: 'schemaId',
           type: 'string',
           required: true,
           default: '',
-          description: 'schemaId parameter',
-          displayOptions: {
-            show: {
-              resource: ['analysis / schemas'],
-              operation: ['schemas'],
-            },
-          },
-        },
-      {
-            displayName: 'Project ID',
-            name: 'project',
-            type: 'string',
-            required: true,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['analysis / schemas'],
-                operation: ['schemas'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'project': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Schema ID',
-            name: 'schemaId',
-            type: 'string',
-            required: true,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['analysis / schemas'],
-                operation: ['schemas'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'schemaId': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-          displayName: 'Project',
-          name: 'project',
-          type: 'string',
-          required: true,
-          default: 'default',
-          description: 'Project identifier to operate on',
-          displayOptions: {
-            show: {
-              resource: ['analysis / schemas'],
-              operation: ['schemas'],
-            },
-          },
-        },
-      {
-          displayName: 'SchemaId',
-          name: 'schemaId',
-          type: 'string',
-          required: true,
-          default: '',
-          description: 'schemaId parameter',
+          description: 'Schema Id parameter',
           displayOptions: {
             show: {
               resource: ['analysis / schemas'],
@@ -1349,7 +1343,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'name': '={{$value}}',
                 },
               },
@@ -1370,29 +1364,8 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'scopes': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Expiration in days',
-            name: 'expiresInDays',
-            type: 'number',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['apikeys'],
-                operation: ['create'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'expiresInDays': '={{$value}}',
                 },
               },
             },
@@ -1410,6 +1383,36 @@ export class MsgCore implements INodeType {
               operation: ['create'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['apikeys'],
+              operation: ['create'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Expiration in days',
+              name: 'expiresInDays',
+              type: 'number',
+              default: 0,
+              description: 'Expiration in days',
+              
+              routing: {
+                request: {
+                  body: {
+                    'expiresInDays': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
           displayName: 'Project',
@@ -1461,12 +1464,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'KeyId',
+          displayName: 'Key Id',
           name: 'keyId',
           type: 'string',
           required: true,
           default: '',
-          description: 'keyId parameter',
+          description: 'Key Id parameter',
           displayOptions: {
             show: {
               resource: ['apikeys'],
@@ -1489,7 +1492,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'keyId': '={{$value}}',
                 },
               },
@@ -1510,12 +1513,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'KeyId',
+          displayName: 'Key Id',
           name: 'keyId',
           type: 'string',
           required: true,
           default: '',
-          description: 'keyId parameter',
+          description: 'Key Id parameter',
           displayOptions: {
             show: {
               resource: ['apikeys'],
@@ -1630,7 +1633,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'email': '={{$value}}',
                 },
               },
@@ -1651,33 +1654,42 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'password': '={{$value}}',
                 },
               },
             },
           },
       {
-            displayName: 'Full name',
-            name: 'name',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['auth'],
-                operation: ['signup'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'name': '={{$value}}',
-                },
-              },
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['auth'],
+              operation: ['signup'],
             },
           },
+          options: [
+            {
+              displayName: 'Full name',
+              name: 'name',
+              type: 'string',
+              default: "",
+              description: 'Full name',
+              
+              routing: {
+                request: {
+                  body: {
+                    'name': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
+        },
       {
             displayName: 'Email address',
             name: 'email',
@@ -1693,7 +1705,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'email': '={{$value}}',
                 },
               },
@@ -1714,7 +1726,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'password': '={{$value}}',
                 },
               },
@@ -1735,7 +1747,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'token': '={{$value}}',
                 },
               },
@@ -1756,7 +1768,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'name': '={{$value}}',
                 },
               },
@@ -1777,7 +1789,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'password': '={{$value}}',
                 },
               },
@@ -1798,7 +1810,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'currentPassword': '={{$value}}',
                 },
               },
@@ -1819,33 +1831,42 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'newPassword': '={{$value}}',
                 },
               },
             },
           },
       {
-            displayName: 'Full name',
-            name: 'name',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['auth'],
-                operation: ['update-profile'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'name': '={{$value}}',
-                },
-              },
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['auth'],
+              operation: ['update-profile'],
             },
           },
+          options: [
+            {
+              displayName: 'Full name',
+              name: 'name',
+              type: 'string',
+              default: "",
+              description: 'Full name',
+              
+              routing: {
+                request: {
+                  body: {
+                    'name': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
+        },
       {
         displayName: 'Operation',
         name: 'operation',
@@ -1940,7 +1961,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'tier': '={{$value}}',
                 },
               },
@@ -1961,7 +1982,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'interval': '={{$value}}',
                 },
               },
@@ -2060,111 +2081,6 @@ export class MsgCore implements INodeType {
         default: 'list',
       },
       {
-            displayName: 'Filter by platform ID',
-            name: 'platformId',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['list'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'platformId': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Filter by chat type (individual, group, channel)',
-            name: 'chatType',
-            type: 'string',
-            required: false,
-            default: "",
-            options: [{name: 'individual', value: 'individual'}, {name: 'group', value: 'group'}, {name: 'channel', value: 'channel'}],
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['list'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'chatType': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Search chats by name or provider chat ID',
-            name: 'search',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['list'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'search': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Number of chats to return',
-            name: 'limit',
-            type: 'number',
-            required: false,
-            default: 50,
-            
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['list'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'limit': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Number of chats to skip',
-            name: 'offset',
-            type: 'number',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['list'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'offset': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
           displayName: 'Project',
           name: 'project',
           type: 'string',
@@ -2177,6 +2093,96 @@ export class MsgCore implements INodeType {
               operation: ['list'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['chats'],
+              operation: ['list'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Filter by platform ID',
+              name: 'platformId',
+              type: 'string',
+              default: "",
+              description: 'Filter by platform ID',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'platformId': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Filter by chat type (individual, group, channel)',
+              name: 'chatType',
+              type: 'string',
+              default: "",
+              description: 'Filter by chat type (individual, group, channel)',
+              options: [{name: 'individual', value: 'individual'}, {name: 'group', value: 'group'}, {name: 'channel', value: 'channel'}],
+              routing: {
+                request: {
+                  qs: {
+                    'chatType': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Search chats by name or provider chat ID',
+              name: 'search',
+              type: 'string',
+              default: "",
+              description: 'Search chats by name or provider chat ID',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'search': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Number of chats to return',
+              name: 'limit',
+              type: 'number',
+              default: 50,
+              description: 'Number of chats to return',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'limit': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Number of chats to skip',
+              name: 'offset',
+              type: 'number',
+              default: 0,
+              description: 'Number of chats to skip',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'offset': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
             displayName: 'Chat ID',
@@ -2214,12 +2220,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'ChatId',
+          displayName: 'Chat Id',
           name: 'chatId',
           type: 'string',
           required: true,
           default: '',
-          description: 'chatId parameter',
+          description: 'Chat Id parameter',
           displayOptions: {
             show: {
               resource: ['chats'],
@@ -2249,48 +2255,6 @@ export class MsgCore implements INodeType {
             },
           },
       {
-            displayName: 'Number of messages to return',
-            name: 'limit',
-            type: 'number',
-            required: false,
-            default: 50,
-            
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['messages'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'limit': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Number of messages to skip',
-            name: 'offset',
-            type: 'number',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['messages'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'offset': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
           displayName: 'Project',
           name: 'project',
           type: 'string',
@@ -2305,18 +2269,63 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'ChatId',
+          displayName: 'Chat Id',
           name: 'chatId',
           type: 'string',
           required: true,
           default: '',
-          description: 'chatId parameter',
+          description: 'Chat Id parameter',
           displayOptions: {
             show: {
               resource: ['chats'],
               operation: ['messages'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['chats'],
+              operation: ['messages'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Number of messages to return',
+              name: 'limit',
+              type: 'number',
+              default: 50,
+              description: 'Number of messages to return',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'limit': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Number of messages to skip',
+              name: 'offset',
+              type: 'number',
+              default: 0,
+              description: 'Number of messages to skip',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'offset': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
             displayName: 'Chat ID',
@@ -2333,71 +2342,8 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'chatId': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Chat display name',
-            name: 'name',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'name': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Chat avatar URL',
-            name: 'avatarUrl',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'avatarUrl': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Custom metadata (JSON string)',
-            name: 'metadata',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'metadata': '={{$value}}',
                 },
               },
             },
@@ -2417,12 +2363,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'ChatId',
+          displayName: 'Chat Id',
           name: 'chatId',
           type: 'string',
           required: true,
           default: '',
-          description: 'chatId parameter',
+          description: 'Chat Id parameter',
           displayOptions: {
             show: {
               resource: ['chats'],
@@ -2431,89 +2377,65 @@ export class MsgCore implements INodeType {
           },
         },
       {
-            displayName: 'Optional: Sync only chats from specific platform',
-            name: 'platformId',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['sync-all'],
-              },
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['chats'],
+              operation: ['update'],
             },
-            routing: {
-              request: {
-                qs: {
-                  'platformId': '={{$value}}',
+          },
+          options: [
+            {
+              displayName: 'Chat display name',
+              name: 'name',
+              type: 'string',
+              default: "",
+              description: 'Chat display name',
+              
+              routing: {
+                request: {
+                  body: {
+                    'name': '={{$value}}',
+                  },
                 },
               },
             },
-          },
-      {
-            displayName: 'Start date for history sync (ISO 8601)',
-            name: 'startDate',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['sync-all'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'startDate': '={{$value}}',
+            {
+              displayName: 'Chat avatar URL',
+              name: 'avatarUrl',
+              type: 'string',
+              default: "",
+              description: 'Chat avatar URL',
+              
+              routing: {
+                request: {
+                  body: {
+                    'avatarUrl': '={{$value}}',
+                  },
                 },
               },
             },
-          },
-      {
-            displayName: 'End date for history sync (ISO 8601)',
-            name: 'endDate',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['sync-all'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'endDate': '={{$value}}',
+            {
+              displayName: 'Custom metadata (JSON string)',
+              name: 'metadata',
+              type: 'string',
+              default: "",
+              description: 'Custom metadata (JSON string)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'metadata': '={{$value}}',
+                  },
                 },
               },
-            },
-          },
-      {
-            displayName: 'Maximum number of messages to sync per chat (1-1000)',
-            name: 'limit',
-            type: 'number',
-            required: false,
-            default: 100,
-            
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['sync-all'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'limit': '={{$value}}',
-                },
-              },
-            },
-          },
+            }
+          ],
+        },
       {
           displayName: 'Project',
           name: 'project',
@@ -2529,6 +2451,81 @@ export class MsgCore implements INodeType {
           },
         },
       {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['chats'],
+              operation: ['sync-all'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Optional: Sync only chats from specific platform',
+              name: 'platformId',
+              type: 'string',
+              default: "",
+              description: 'Optional: Sync only chats from specific platform',
+              
+              routing: {
+                request: {
+                  body: {
+                    'platformId': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Start date for history sync (ISO 8601)',
+              name: 'startDate',
+              type: 'string',
+              default: "",
+              description: 'Start date for history sync (ISO 8601)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'startDate': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'End date for history sync (ISO 8601)',
+              name: 'endDate',
+              type: 'string',
+              default: "",
+              description: 'End date for history sync (ISO 8601)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'endDate': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Maximum number of messages to sync per chat (1-1000)',
+              name: 'limit',
+              type: 'number',
+              default: 100,
+              description: 'Maximum number of messages to sync per chat (1-1000)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'limit': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
+        },
+      {
             displayName: 'Chat ID',
             name: 'chatId',
             type: 'string',
@@ -2543,71 +2540,8 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'chatId': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Start date for history sync (ISO 8601)',
-            name: 'startDate',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['sync'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'startDate': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'End date for history sync (ISO 8601)',
-            name: 'endDate',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['sync'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'endDate': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Maximum number of messages to sync (1-1000)',
-            name: 'limit',
-            type: 'number',
-            required: false,
-            default: 100,
-            
-            displayOptions: {
-              show: {
-                resource: ['chats'],
-                operation: ['sync'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'limit': '={{$value}}',
                 },
               },
             },
@@ -2627,18 +2561,78 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'ChatId',
+          displayName: 'Chat Id',
           name: 'chatId',
           type: 'string',
           required: true,
           default: '',
-          description: 'chatId parameter',
+          description: 'Chat Id parameter',
           displayOptions: {
             show: {
               resource: ['chats'],
               operation: ['sync'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['chats'],
+              operation: ['sync'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Start date for history sync (ISO 8601)',
+              name: 'startDate',
+              type: 'string',
+              default: "",
+              description: 'Start date for history sync (ISO 8601)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'startDate': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'End date for history sync (ISO 8601)',
+              name: 'endDate',
+              type: 'string',
+              default: "",
+              description: 'End date for history sync (ISO 8601)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'endDate': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Maximum number of messages to sync (1-1000)',
+              name: 'limit',
+              type: 'number',
+              default: 100,
+              description: 'Maximum number of messages to sync (1-1000)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'limit': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
         displayName: 'Operation',
@@ -2811,69 +2805,6 @@ export class MsgCore implements INodeType {
         default: 'create',
       },
       {
-            displayName: 'Display name for the identity',
-            name: 'displayName',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['identities'],
-                operation: ['create'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'displayName': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Email address for the identity',
-            name: 'email',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['identities'],
-                operation: ['create'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'email': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'JSON metadata for the identity',
-            name: 'metadata',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['identities'],
-                operation: ['create'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'metadata': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
             displayName: 'JSON array of platform aliases',
             name: 'aliases',
             type: 'string',
@@ -2888,7 +2819,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'aliases': '={{$value}}',
                 },
               },
@@ -2907,6 +2838,66 @@ export class MsgCore implements INodeType {
               operation: ['create'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['identities'],
+              operation: ['create'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Display name for the identity',
+              name: 'displayName',
+              type: 'string',
+              default: "",
+              description: 'Display name for the identity',
+              
+              routing: {
+                request: {
+                  body: {
+                    'displayName': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Email address for the identity',
+              name: 'email',
+              type: 'string',
+              default: "",
+              description: 'Email address for the identity',
+              
+              routing: {
+                request: {
+                  body: {
+                    'email': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'JSON metadata for the identity',
+              name: 'metadata',
+              type: 'string',
+              default: "",
+              description: 'JSON metadata for the identity',
+              
+              routing: {
+                request: {
+                  body: {
+                    'metadata': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
           displayName: 'Project',
@@ -2972,7 +2963,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'platformId': '={{$value}}',
                 },
               },
@@ -2993,71 +2984,8 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'providerUserId': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Display name on the platform',
-            name: 'providerUserDisplay',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['identities'],
-                operation: ['quick-link'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'providerUserDisplay': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Display name for the new identity',
-            name: 'displayName',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['identities'],
-                operation: ['quick-link'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'displayName': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Email address for the new identity',
-            name: 'email',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['identities'],
-                operation: ['quick-link'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'email': '={{$value}}',
                 },
               },
             },
@@ -3075,6 +3003,66 @@ export class MsgCore implements INodeType {
               operation: ['quick-link'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['identities'],
+              operation: ['quick-link'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Display name on the platform',
+              name: 'providerUserDisplay',
+              type: 'string',
+              default: "",
+              description: 'Display name on the platform',
+              
+              routing: {
+                request: {
+                  body: {
+                    'providerUserDisplay': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Display name for the new identity',
+              name: 'displayName',
+              type: 'string',
+              default: "",
+              description: 'Display name for the new identity',
+              
+              routing: {
+                request: {
+                  body: {
+                    'displayName': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Email address for the new identity',
+              name: 'email',
+              type: 'string',
+              default: "",
+              description: 'Email address for the new identity',
+              
+              routing: {
+                request: {
+                  body: {
+                    'email': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
             displayName: 'Platform configuration ID',
@@ -3173,7 +3161,7 @@ export class MsgCore implements INodeType {
           type: 'string',
           required: true,
           default: '',
-          description: 'id parameter',
+          description: 'Id parameter',
           displayOptions: {
             show: {
               resource: ['identities'],
@@ -3196,71 +3184,8 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'id': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Updated display name',
-            name: 'displayName',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['identities'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'displayName': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Updated email address',
-            name: 'email',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['identities'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'email': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Updated JSON metadata',
-            name: 'metadata',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['identities'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'metadata': '={{$value}}',
                 },
               },
             },
@@ -3285,13 +3210,73 @@ export class MsgCore implements INodeType {
           type: 'string',
           required: true,
           default: '',
-          description: 'id parameter',
+          description: 'Id parameter',
           displayOptions: {
             show: {
               resource: ['identities'],
               operation: ['update'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['identities'],
+              operation: ['update'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Updated display name',
+              name: 'displayName',
+              type: 'string',
+              default: "",
+              description: 'Updated display name',
+              
+              routing: {
+                request: {
+                  body: {
+                    'displayName': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Updated email address',
+              name: 'email',
+              type: 'string',
+              default: "",
+              description: 'Updated email address',
+              
+              routing: {
+                request: {
+                  body: {
+                    'email': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Updated JSON metadata',
+              name: 'metadata',
+              type: 'string',
+              default: "",
+              description: 'Updated JSON metadata',
+              
+              routing: {
+                request: {
+                  body: {
+                    'metadata': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
             displayName: 'Identity ID',
@@ -3308,7 +3293,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'id': '={{$value}}',
                 },
               },
@@ -3329,7 +3314,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'platformId': '={{$value}}',
                 },
               },
@@ -3350,29 +3335,8 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'providerUserId': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Display name on the platform',
-            name: 'providerUserDisplay',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['identities'],
-                operation: ['add-alias'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'providerUserDisplay': '={{$value}}',
                 },
               },
             },
@@ -3397,13 +3361,43 @@ export class MsgCore implements INodeType {
           type: 'string',
           required: true,
           default: '',
-          description: 'id parameter',
+          description: 'Id parameter',
           displayOptions: {
             show: {
               resource: ['identities'],
               operation: ['add-alias'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['identities'],
+              operation: ['add-alias'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Display name on the platform',
+              name: 'providerUserDisplay',
+              type: 'string',
+              default: "",
+              description: 'Display name on the platform',
+              
+              routing: {
+                request: {
+                  body: {
+                    'providerUserDisplay': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
             displayName: 'Identity ID',
@@ -3467,7 +3461,7 @@ export class MsgCore implements INodeType {
           type: 'string',
           required: true,
           default: '',
-          description: 'id parameter',
+          description: 'Id parameter',
           displayOptions: {
             show: {
               resource: ['identities'],
@@ -3476,12 +3470,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'AliasId',
+          displayName: 'Alias Id',
           name: 'aliasId',
           type: 'string',
           required: true,
           default: '',
-          description: 'aliasId parameter',
+          description: 'Alias Id parameter',
           displayOptions: {
             show: {
               resource: ['identities'],
@@ -3530,7 +3524,7 @@ export class MsgCore implements INodeType {
           type: 'string',
           required: true,
           default: '',
-          description: 'id parameter',
+          description: 'Id parameter',
           displayOptions: {
             show: {
               resource: ['identities'],
@@ -3579,7 +3573,7 @@ export class MsgCore implements INodeType {
           type: 'string',
           required: true,
           default: '',
-          description: 'id parameter',
+          description: 'Id parameter',
           displayOptions: {
             show: {
               resource: ['identities'],
@@ -3628,7 +3622,7 @@ export class MsgCore implements INodeType {
           type: 'string',
           required: true,
           default: '',
-          description: 'id parameter',
+          description: 'Id parameter',
           displayOptions: {
             show: {
               resource: ['identities'],
@@ -3744,7 +3738,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'email': '={{$value}}',
                 },
               },
@@ -3765,7 +3759,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'role': '={{$value}}',
                 },
               },
@@ -3800,7 +3794,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'userId': '={{$value}}',
                 },
               },
@@ -3821,7 +3815,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'role': '={{$value}}',
                 },
               },
@@ -3842,12 +3836,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'UserId',
+          displayName: 'User Id',
           name: 'userId',
           type: 'string',
           required: true,
           default: '',
-          description: 'userId parameter',
+          description: 'User Id parameter',
           displayOptions: {
             show: {
               resource: ['members'],
@@ -3891,12 +3885,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'UserId',
+          displayName: 'User Id',
           name: 'userId',
           type: 'string',
           required: true,
           default: '',
-          description: 'userId parameter',
+          description: 'User Id parameter',
           displayOptions: {
             show: {
               resource: ['members'],
@@ -3919,7 +3913,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'email': '={{$value}}',
                 },
               },
@@ -4071,237 +4065,6 @@ export class MsgCore implements INodeType {
         default: 'list',
       },
       {
-            displayName: 'Filter by platform ID',
-            name: 'platformId',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['messages'],
-                operation: ['list'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'platformId': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Filter by chat/channel ID',
-            name: 'chatId',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['messages'],
-                operation: ['list'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'chatId': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Filter by user ID',
-            name: 'userId',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['messages'],
-                operation: ['list'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'userId': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Filter by message direction',
-            name: 'direction',
-            type: 'string',
-            required: false,
-            default: "",
-            options: [{name: 'sent', value: 'sent'}, {name: 'received', value: 'received'}],
-            displayOptions: {
-              show: {
-                resource: ['messages'],
-                operation: ['list'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'direction': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Filter messages after this date (ISO 8601)',
-            name: 'startDate',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['messages'],
-                operation: ['list'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'startDate': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Filter messages before this date (ISO 8601)',
-            name: 'endDate',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['messages'],
-                operation: ['list'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'endDate': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Number of messages to return (1-100)',
-            name: 'limit',
-            type: 'number',
-            required: false,
-            default: 50,
-            
-            displayOptions: {
-              show: {
-                resource: ['messages'],
-                operation: ['list'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'limit': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Number of messages to skip',
-            name: 'offset',
-            type: 'number',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['messages'],
-                operation: ['list'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'offset': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Sort order (asc or desc)',
-            name: 'order',
-            type: 'string',
-            required: false,
-            default: "desc",
-            options: [{name: 'asc', value: 'asc'}, {name: 'desc', value: 'desc'}],
-            displayOptions: {
-              show: {
-                resource: ['messages'],
-                operation: ['list'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'order': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Include raw platform message data',
-            name: 'raw',
-            type: 'boolean',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['messages'],
-                operation: ['list'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'raw': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Include reactions on each message',
-            name: 'reactions',
-            type: 'boolean',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['messages'],
-                operation: ['list'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'reactions': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
           displayName: 'Project',
           name: 'project',
           type: 'string',
@@ -4314,6 +4077,186 @@ export class MsgCore implements INodeType {
               operation: ['list'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['messages'],
+              operation: ['list'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Filter by platform ID',
+              name: 'platformId',
+              type: 'string',
+              default: "",
+              description: 'Filter by platform ID',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'platformId': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Filter by chat/channel ID',
+              name: 'chatId',
+              type: 'string',
+              default: "",
+              description: 'Filter by chat/channel ID',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'chatId': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Filter by user ID',
+              name: 'userId',
+              type: 'string',
+              default: "",
+              description: 'Filter by user ID',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'userId': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Filter by message direction',
+              name: 'direction',
+              type: 'string',
+              default: "",
+              description: 'Filter by message direction',
+              options: [{name: 'sent', value: 'sent'}, {name: 'received', value: 'received'}],
+              routing: {
+                request: {
+                  qs: {
+                    'direction': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Filter messages after this date (ISO 8601)',
+              name: 'startDate',
+              type: 'string',
+              default: "",
+              description: 'Filter messages after this date (ISO 8601)',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'startDate': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Filter messages before this date (ISO 8601)',
+              name: 'endDate',
+              type: 'string',
+              default: "",
+              description: 'Filter messages before this date (ISO 8601)',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'endDate': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Number of messages to return (1-100)',
+              name: 'limit',
+              type: 'number',
+              default: 50,
+              description: 'Number of messages to return (1-100)',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'limit': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Number of messages to skip',
+              name: 'offset',
+              type: 'number',
+              default: 0,
+              description: 'Number of messages to skip',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'offset': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Sort order (asc or desc)',
+              name: 'order',
+              type: 'string',
+              default: "desc",
+              description: 'Sort order (asc or desc)',
+              options: [{name: 'asc', value: 'asc'}, {name: 'desc', value: 'desc'}],
+              routing: {
+                request: {
+                  qs: {
+                    'order': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Include raw platform message data',
+              name: 'raw',
+              type: 'boolean',
+              default: false,
+              description: 'Include raw platform message data',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'raw': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Include reactions on each message',
+              name: 'reactions',
+              type: 'boolean',
+              default: false,
+              description: 'Include reactions on each message',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'reactions': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
           displayName: 'Project',
@@ -4365,12 +4308,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'MessageId',
+          displayName: 'Message Id',
           name: 'messageId',
           type: 'string',
           required: true,
           default: '',
-          description: 'messageId parameter',
+          description: 'Message Id parameter',
           displayOptions: {
             show: {
               resource: ['messages'],
@@ -4383,7 +4326,7 @@ export class MsgCore implements INodeType {
             name: 'daysBefore',
             type: 'number',
             required: true,
-            default: "",
+            default: 0,
             
             displayOptions: {
               show: {
@@ -4414,10 +4357,10 @@ export class MsgCore implements INodeType {
           },
         },
       {
-            displayName: 'Single target in format: platformId:type:id',
+            displayName: 'Target(s) in format platformId:type:id. For multiple, comma-separate: p1:user:1,p2:channel:2',
             name: 'target',
             type: 'string',
-            required: false,
+            required: true,
             default: "",
             
             displayOptions: {
@@ -4428,113 +4371,8 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'target': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Multiple targets comma-separated: platformId:type:id,platformId:type:id',
-            name: 'targets',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['messages'],
-                operation: ['send'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'targets': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Message text content',
-            name: 'text',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['messages'],
-                operation: ['send'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'text': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Full message content object (advanced)',
-            name: 'content',
-            type: 'json',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['messages'],
-                operation: ['send'],
-              },
-            },
-            routing: {
-              request: {
-                body: {
-                  'content': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Message options',
-            name: 'options',
-            type: 'json',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['messages'],
-                operation: ['send'],
-              },
-            },
-            routing: {
-              request: {
-                body: {
-                  'options': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Message metadata',
-            name: 'metadata',
-            type: 'json',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['messages'],
-                operation: ['send'],
-              },
-            },
-            routing: {
-              request: {
-                body: {
-                  'metadata': '={{$value}}',
                 },
               },
             },
@@ -4552,6 +4390,81 @@ export class MsgCore implements INodeType {
               operation: ['send'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['messages'],
+              operation: ['send'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Message text content',
+              name: 'text',
+              type: 'string',
+              default: "",
+              description: 'Message text content',
+              
+              routing: {
+                request: {
+                  body: {
+                    'text': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Full content object (text, markdown, html, attachments, buttons, embeds)',
+              name: 'content',
+              type: 'json',
+              default: "",
+              description: 'Full content object (text, markdown, html, attachments, buttons, embeds)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'content': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Message options (replyTo, silent, scheduled)',
+              name: 'options',
+              type: 'json',
+              default: "",
+              description: 'Message options (replyTo, silent, scheduled)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'options': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Message metadata (trackingId, tags, priority)',
+              name: 'metadata',
+              type: 'json',
+              default: "",
+              description: 'Message metadata (trackingId, tags, priority)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'metadata': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
             displayName: 'Message job ID',
@@ -4589,12 +4502,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'JobId',
+          displayName: 'Job Id',
           name: 'jobId',
           type: 'string',
           required: true,
           default: '',
-          description: 'jobId parameter',
+          description: 'Job Id parameter',
           displayOptions: {
             show: {
               resource: ['messages'],
@@ -4617,7 +4530,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'jobId': '={{$value}}',
                 },
               },
@@ -4638,12 +4551,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'JobId',
+          displayName: 'Job Id',
           name: 'jobId',
           type: 'string',
           required: true,
           default: '',
-          description: 'jobId parameter',
+          description: 'Job Id parameter',
           displayOptions: {
             show: {
               resource: ['messages'],
@@ -4666,7 +4579,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'platformId': '={{$value}}',
                 },
               },
@@ -4687,7 +4600,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'messageId': '={{$value}}',
                 },
               },
@@ -4708,7 +4621,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'emoji': '={{$value}}',
                 },
               },
@@ -4743,7 +4656,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'platformId': '={{$value}}',
                 },
               },
@@ -4764,7 +4677,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'messageId': '={{$value}}',
                 },
               },
@@ -4785,7 +4698,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'emoji': '={{$value}}',
                 },
               },
@@ -4859,152 +4772,139 @@ export class MsgCore implements INodeType {
         default: 'logs',
       },
       {
-            displayName: 'Filter by platform (telegram, discord)',
-            name: 'platform',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['platform logs'],
-                operation: ['logs'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'platform': '={{$value}}',
-                },
-              },
+          displayName: 'Project',
+          name: 'project',
+          type: 'string',
+          required: true,
+          default: 'default',
+          description: 'Project identifier to operate on',
+          displayOptions: {
+            show: {
+              resource: ['platform logs'],
+              operation: ['logs'],
             },
           },
+        },
       {
-            displayName: 'Filter by log level',
-            name: 'level',
-            type: 'string',
-            required: false,
-            default: "",
-            options: [{name: 'info', value: 'info'}, {name: 'warn', value: 'warn'}, {name: 'error', value: 'error'}, {name: 'debug', value: 'debug'}],
-            displayOptions: {
-              show: {
-                resource: ['platform logs'],
-                operation: ['logs'],
-              },
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['platform logs'],
+              operation: ['logs'],
             },
-            routing: {
-              request: {
-                qs: {
-                  'level': '={{$value}}',
+          },
+          options: [
+            {
+              displayName: 'Filter by platform (telegram, discord)',
+              name: 'platform',
+              type: 'string',
+              default: "",
+              description: 'Filter by platform (telegram, discord)',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'platform': '={{$value}}',
+                  },
                 },
               },
             },
-          },
-      {
-            displayName: 'Filter by log category',
-            name: 'category',
-            type: 'string',
-            required: false,
-            default: "",
-            options: [{name: 'connection', value: 'connection'}, {name: 'webhook', value: 'webhook'}, {name: 'message', value: 'message'}, {name: 'error', value: 'error'}, {name: 'auth', value: 'auth'}, {name: 'general', value: 'general'}],
-            displayOptions: {
-              show: {
-                resource: ['platform logs'],
-                operation: ['logs'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'category': '={{$value}}',
+            {
+              displayName: 'Filter by log level',
+              name: 'level',
+              type: 'string',
+              default: "",
+              description: 'Filter by log level',
+              options: [{name: 'info', value: 'info'}, {name: 'warn', value: 'warn'}, {name: 'error', value: 'error'}, {name: 'debug', value: 'debug'}],
+              routing: {
+                request: {
+                  qs: {
+                    'level': '={{$value}}',
+                  },
                 },
               },
             },
-          },
-      {
-            displayName: 'Filter logs after this date (ISO 8601)',
-            name: 'startDate',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['platform logs'],
-                operation: ['logs'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'startDate': '={{$value}}',
+            {
+              displayName: 'Filter by log category',
+              name: 'category',
+              type: 'string',
+              default: "",
+              description: 'Filter by log category',
+              options: [{name: 'connection', value: 'connection'}, {name: 'webhook', value: 'webhook'}, {name: 'message', value: 'message'}, {name: 'error', value: 'error'}, {name: 'auth', value: 'auth'}, {name: 'general', value: 'general'}],
+              routing: {
+                request: {
+                  qs: {
+                    'category': '={{$value}}',
+                  },
                 },
               },
             },
-          },
-      {
-            displayName: 'Filter logs before this date (ISO 8601)',
-            name: 'endDate',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['platform logs'],
-                operation: ['logs'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'endDate': '={{$value}}',
+            {
+              displayName: 'Filter logs after this date (ISO 8601)',
+              name: 'startDate',
+              type: 'string',
+              default: "",
+              description: 'Filter logs after this date (ISO 8601)',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'startDate': '={{$value}}',
+                  },
                 },
               },
             },
-          },
-      {
-            displayName: 'Number of logs to return (1-1000)',
-            name: 'limit',
-            type: 'number',
-            required: false,
-            default: "100",
-            
-            displayOptions: {
-              show: {
-                resource: ['platform logs'],
-                operation: ['logs'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'limit': '={{$value}}',
+            {
+              displayName: 'Filter logs before this date (ISO 8601)',
+              name: 'endDate',
+              type: 'string',
+              default: "",
+              description: 'Filter logs before this date (ISO 8601)',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'endDate': '={{$value}}',
+                  },
                 },
               },
             },
-          },
-      {
-            displayName: 'Number of logs to skip',
-            name: 'offset',
-            type: 'number',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['platform logs'],
-                operation: ['logs'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'offset': '={{$value}}',
+            {
+              displayName: 'Number of logs to return (1-1000)',
+              name: 'limit',
+              type: 'number',
+              default: "100",
+              description: 'Number of logs to return (1-1000)',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'limit': '={{$value}}',
+                  },
                 },
               },
             },
-          },
+            {
+              displayName: 'Number of logs to skip',
+              name: 'offset',
+              type: 'number',
+              default: 0,
+              description: 'Number of logs to skip',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'offset': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
+        },
       {
           displayName: 'Project',
           name: 'project',
@@ -5020,158 +4920,123 @@ export class MsgCore implements INodeType {
           },
         },
       {
-            displayName: 'Filter by log level',
-            name: 'level',
-            type: 'string',
-            required: false,
-            default: "",
-            options: [{name: 'info', value: 'info'}, {name: 'warn', value: 'warn'}, {name: 'error', value: 'error'}, {name: 'debug', value: 'debug'}],
-            displayOptions: {
-              show: {
-                resource: ['platform logs'],
-                operation: ['logs'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'level': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Filter by log category',
-            name: 'category',
-            type: 'string',
-            required: false,
-            default: "",
-            options: [{name: 'connection', value: 'connection'}, {name: 'webhook', value: 'webhook'}, {name: 'message', value: 'message'}, {name: 'error', value: 'error'}, {name: 'auth', value: 'auth'}, {name: 'general', value: 'general'}],
-            displayOptions: {
-              show: {
-                resource: ['platform logs'],
-                operation: ['logs'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'category': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Filter logs after this date (ISO 8601)',
-            name: 'startDate',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['platform logs'],
-                operation: ['logs'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'startDate': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Filter logs before this date (ISO 8601)',
-            name: 'endDate',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['platform logs'],
-                operation: ['logs'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'endDate': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Number of logs to return (1-1000)',
-            name: 'limit',
-            type: 'number',
-            required: false,
-            default: "100",
-            
-            displayOptions: {
-              show: {
-                resource: ['platform logs'],
-                operation: ['logs'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'limit': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Number of logs to skip',
-            name: 'offset',
-            type: 'number',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['platform logs'],
-                operation: ['logs'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'offset': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-          displayName: 'Project',
-          name: 'project',
-          type: 'string',
-          required: true,
-          default: 'default',
-          description: 'Project identifier to operate on',
-          displayOptions: {
-            show: {
-              resource: ['platform logs'],
-              operation: ['logs'],
-            },
-          },
-        },
-      {
-          displayName: 'PlatformId',
+          displayName: 'Platform Id',
           name: 'platformId',
           type: 'string',
           required: true,
           default: '',
-          description: 'platformId parameter',
+          description: 'Platform Id parameter',
           displayOptions: {
             show: {
               resource: ['platform logs'],
               operation: ['logs'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['platform logs'],
+              operation: ['logs'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Filter by log level',
+              name: 'level',
+              type: 'string',
+              default: "",
+              description: 'Filter by log level',
+              options: [{name: 'info', value: 'info'}, {name: 'warn', value: 'warn'}, {name: 'error', value: 'error'}, {name: 'debug', value: 'debug'}],
+              routing: {
+                request: {
+                  qs: {
+                    'level': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Filter by log category',
+              name: 'category',
+              type: 'string',
+              default: "",
+              description: 'Filter by log category',
+              options: [{name: 'connection', value: 'connection'}, {name: 'webhook', value: 'webhook'}, {name: 'message', value: 'message'}, {name: 'error', value: 'error'}, {name: 'auth', value: 'auth'}, {name: 'general', value: 'general'}],
+              routing: {
+                request: {
+                  qs: {
+                    'category': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Filter logs after this date (ISO 8601)',
+              name: 'startDate',
+              type: 'string',
+              default: "",
+              description: 'Filter logs after this date (ISO 8601)',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'startDate': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Filter logs before this date (ISO 8601)',
+              name: 'endDate',
+              type: 'string',
+              default: "",
+              description: 'Filter logs before this date (ISO 8601)',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'endDate': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Number of logs to return (1-1000)',
+              name: 'limit',
+              type: 'number',
+              default: "100",
+              description: 'Number of logs to return (1-1000)',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'limit': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Number of logs to skip',
+              name: 'offset',
+              type: 'number',
+              default: 0,
+              description: 'Number of logs to skip',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'offset': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
           displayName: 'Project',
@@ -5320,7 +5185,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'platform': '={{$value}}',
                 },
               },
@@ -5341,29 +5206,8 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'name': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Optional description for the platform instance',
-            name: 'description',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['platforms'],
-                operation: ['create'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'description': '={{$value}}',
                 },
               },
             },
@@ -5390,48 +5234,6 @@ export class MsgCore implements INodeType {
             },
           },
       {
-            displayName: 'Enable platform',
-            name: 'isActive',
-            type: 'boolean',
-            required: false,
-            default: true,
-            
-            displayOptions: {
-              show: {
-                resource: ['platforms'],
-                operation: ['create'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'isActive': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Enable test mode',
-            name: 'testMode',
-            type: 'boolean',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['platforms'],
-                operation: ['create'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'testMode': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
           displayName: 'Project',
           name: 'project',
           type: 'string',
@@ -5444,6 +5246,66 @@ export class MsgCore implements INodeType {
               operation: ['create'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['platforms'],
+              operation: ['create'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Optional description for the platform instance',
+              name: 'description',
+              type: 'string',
+              default: "",
+              description: 'Optional description for the platform instance',
+              
+              routing: {
+                request: {
+                  body: {
+                    'description': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Enable platform',
+              name: 'isActive',
+              type: 'boolean',
+              default: true,
+              description: 'Enable platform',
+              
+              routing: {
+                request: {
+                  body: {
+                    'isActive': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Enable test mode',
+              name: 'testMode',
+              type: 'boolean',
+              default: false,
+              description: 'Enable test mode',
+              
+              routing: {
+                request: {
+                  body: {
+                    'testMode': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
           displayName: 'Project',
@@ -5500,7 +5362,7 @@ export class MsgCore implements INodeType {
           type: 'string',
           required: true,
           default: '',
-          description: 'id parameter',
+          description: 'Id parameter',
           displayOptions: {
             show: {
               resource: ['platforms'],
@@ -5508,111 +5370,6 @@ export class MsgCore implements INodeType {
             },
           },
         },
-      {
-            displayName: 'Updated friendly name',
-            name: 'name',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['platforms'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'name': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Updated description',
-            name: 'description',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['platforms'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'description': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Updated credentials (JSON object)',
-            name: 'credentials',
-            type: 'json',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['platforms'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                body: {
-                  'credentials': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Enable/disable platform',
-            name: 'isActive',
-            type: 'boolean',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['platforms'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'isActive': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Enable/disable test mode',
-            name: 'testMode',
-            type: 'boolean',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['platforms'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'testMode': '={{$value}}',
-                },
-              },
-            },
-          },
       {
           displayName: 'Project',
           name: 'project',
@@ -5633,13 +5390,103 @@ export class MsgCore implements INodeType {
           type: 'string',
           required: true,
           default: '',
-          description: 'id parameter',
+          description: 'Id parameter',
           displayOptions: {
             show: {
               resource: ['platforms'],
               operation: ['update'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['platforms'],
+              operation: ['update'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Updated friendly name',
+              name: 'name',
+              type: 'string',
+              default: "",
+              description: 'Updated friendly name',
+              
+              routing: {
+                request: {
+                  body: {
+                    'name': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Updated description',
+              name: 'description',
+              type: 'string',
+              default: "",
+              description: 'Updated description',
+              
+              routing: {
+                request: {
+                  body: {
+                    'description': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Updated credentials (JSON object)',
+              name: 'credentials',
+              type: 'json',
+              default: "",
+              description: 'Updated credentials (JSON object)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'credentials': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Enable/disable platform',
+              name: 'isActive',
+              type: 'boolean',
+              default: "",
+              description: 'Enable/disable platform',
+              
+              routing: {
+                request: {
+                  body: {
+                    'isActive': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Enable/disable test mode',
+              name: 'testMode',
+              type: 'boolean',
+              default: "",
+              description: 'Enable/disable test mode',
+              
+              routing: {
+                request: {
+                  body: {
+                    'testMode': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
             displayName: 'Platform ID',
@@ -5682,7 +5529,7 @@ export class MsgCore implements INodeType {
           type: 'string',
           required: true,
           default: '',
-          description: 'id parameter',
+          description: 'Id parameter',
           displayOptions: {
             show: {
               resource: ['platforms'],
@@ -5705,7 +5552,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'id': '={{$value}}',
                 },
               },
@@ -5731,7 +5578,7 @@ export class MsgCore implements INodeType {
           type: 'string',
           required: true,
           default: '',
-          description: 'id parameter',
+          description: 'Id parameter',
           displayOptions: {
             show: {
               resource: ['platforms'],
@@ -5780,7 +5627,7 @@ export class MsgCore implements INodeType {
           type: 'string',
           required: true,
           default: '',
-          description: 'id parameter',
+          description: 'Id parameter',
           displayOptions: {
             show: {
               resource: ['platforms'],
@@ -5882,54 +5729,57 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'name': '={{$value}}',
                 },
               },
             },
           },
       {
-            displayName: 'Project description',
-            name: 'description',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['projects'],
-                operation: ['create'],
-              },
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['projects'],
+              operation: ['create'],
             },
-            routing: {
-              request: {
-                qs: {
-                  'description': '={{$value}}',
+          },
+          options: [
+            {
+              displayName: 'Project description',
+              name: 'description',
+              type: 'string',
+              default: "",
+              description: 'Project description',
+              
+              routing: {
+                request: {
+                  body: {
+                    'description': '={{$value}}',
+                  },
                 },
               },
             },
-          },
-      {
-            displayName: 'Project environment',
-            name: 'environment',
-            type: 'string',
-            required: false,
-            default: "development",
-            options: [{name: 'development', value: 'development'}, {name: 'staging', value: 'staging'}, {name: 'production', value: 'production'}],
-            displayOptions: {
-              show: {
-                resource: ['projects'],
-                operation: ['create'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'environment': '={{$value}}',
+            {
+              displayName: 'Project environment',
+              name: 'environment',
+              type: 'string',
+              default: "development",
+              description: 'Project environment',
+              options: [{name: 'development', value: 'development'}, {name: 'staging', value: 'staging'}, {name: 'production', value: 'production'}],
+              routing: {
+                request: {
+                  body: {
+                    'environment': '={{$value}}',
+                  },
                 },
               },
-            },
-          },
+            }
+          ],
+        },
       {
           displayName: 'Project',
           name: 'project',
@@ -5945,90 +5795,6 @@ export class MsgCore implements INodeType {
           },
         },
       {
-            displayName: 'Project name',
-            name: 'name',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['projects'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'name': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Project description',
-            name: 'description',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['projects'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'description': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Project environment',
-            name: 'environment',
-            type: 'string',
-            required: false,
-            default: "",
-            options: [{name: 'development', value: 'development'}, {name: 'staging', value: 'staging'}, {name: 'production', value: 'production'}],
-            displayOptions: {
-              show: {
-                resource: ['projects'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'environment': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Set as default project',
-            name: 'isDefault',
-            type: 'boolean',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['projects'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'isDefault': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
           displayName: 'Project',
           name: 'project',
           type: 'string',
@@ -6041,6 +5807,81 @@ export class MsgCore implements INodeType {
               operation: ['update'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['projects'],
+              operation: ['update'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Project name',
+              name: 'name',
+              type: 'string',
+              default: "",
+              description: 'Project name',
+              
+              routing: {
+                request: {
+                  body: {
+                    'name': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Project description',
+              name: 'description',
+              type: 'string',
+              default: "",
+              description: 'Project description',
+              
+              routing: {
+                request: {
+                  body: {
+                    'description': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Project environment',
+              name: 'environment',
+              type: 'string',
+              default: "",
+              description: 'Project environment',
+              options: [{name: 'development', value: 'development'}, {name: 'staging', value: 'staging'}, {name: 'production', value: 'production'}],
+              routing: {
+                request: {
+                  body: {
+                    'environment': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Set as default project',
+              name: 'isDefault',
+              type: 'boolean',
+              default: "",
+              description: 'Set as default project',
+              
+              routing: {
+                request: {
+                  body: {
+                    'isDefault': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
           displayName: 'Project',
@@ -6163,7 +6004,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'name': '={{$value}}',
                 },
               },
@@ -6184,7 +6025,7 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'url': '={{$value}}',
                 },
               },
@@ -6205,29 +6046,8 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'events': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Custom webhook secret (auto-generated if not provided)',
-            name: 'secret',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['webhooks'],
-                operation: ['create'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'secret': '={{$value}}',
                 },
               },
             },
@@ -6245,6 +6065,36 @@ export class MsgCore implements INodeType {
               operation: ['create'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['webhooks'],
+              operation: ['create'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Custom webhook secret (auto-generated if not provided)',
+              name: 'secret',
+              type: 'string',
+              default: "",
+              description: 'Custom webhook secret (auto-generated if not provided)',
+              
+              routing: {
+                request: {
+                  body: {
+                    'secret': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
           displayName: 'Project',
@@ -6296,12 +6146,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'WebhookId',
+          displayName: 'Webhook Id',
           name: 'webhookId',
           type: 'string',
           required: true,
           default: '',
-          description: 'webhookId parameter',
+          description: 'Webhook Id parameter',
           displayOptions: {
             show: {
               resource: ['webhooks'],
@@ -6324,92 +6174,8 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                qs: {
+                body: {
                   'webhookId': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'New webhook name',
-            name: 'name',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['webhooks'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'name': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'New webhook URL',
-            name: 'url',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['webhooks'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'url': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'New events subscription',
-            name: 'events',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['webhooks'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'events': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Enable or disable webhook',
-            name: 'isActive',
-            type: 'boolean',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['webhooks'],
-                operation: ['update'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'isActive': '={{$value}}',
                 },
               },
             },
@@ -6429,18 +6195,93 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'WebhookId',
+          displayName: 'Webhook Id',
           name: 'webhookId',
           type: 'string',
           required: true,
           default: '',
-          description: 'webhookId parameter',
+          description: 'Webhook Id parameter',
           displayOptions: {
             show: {
               resource: ['webhooks'],
               operation: ['update'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['webhooks'],
+              operation: ['update'],
+            },
+          },
+          options: [
+            {
+              displayName: 'New webhook name',
+              name: 'name',
+              type: 'string',
+              default: "",
+              description: 'New webhook name',
+              
+              routing: {
+                request: {
+                  body: {
+                    'name': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'New webhook URL',
+              name: 'url',
+              type: 'string',
+              default: "",
+              description: 'New webhook URL',
+              
+              routing: {
+                request: {
+                  body: {
+                    'url': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'New events subscription',
+              name: 'events',
+              type: 'string',
+              default: "",
+              description: 'New events subscription',
+              
+              routing: {
+                request: {
+                  body: {
+                    'events': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Enable or disable webhook',
+              name: 'isActive',
+              type: 'boolean',
+              default: "",
+              description: 'Enable or disable webhook',
+              
+              routing: {
+                request: {
+                  body: {
+                    'isActive': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         },
       {
             displayName: 'Webhook ID',
@@ -6478,12 +6319,12 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'WebhookId',
+          displayName: 'Webhook Id',
           name: 'webhookId',
           type: 'string',
           required: true,
           default: '',
-          description: 'webhookId parameter',
+          description: 'Webhook Id parameter',
           displayOptions: {
             show: {
               resource: ['webhooks'],
@@ -6513,90 +6354,6 @@ export class MsgCore implements INodeType {
             },
           },
       {
-            displayName: 'Filter by event type',
-            name: 'event',
-            type: 'string',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['webhooks'],
-                operation: ['deliveries'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'event': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Filter by delivery status',
-            name: 'status',
-            type: 'string',
-            required: false,
-            default: "",
-            options: [{name: 'pending', value: 'pending'}, {name: 'success', value: 'success'}, {name: 'failed', value: 'failed'}],
-            displayOptions: {
-              show: {
-                resource: ['webhooks'],
-                operation: ['deliveries'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'status': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Number of deliveries to return (1-100)',
-            name: 'limit',
-            type: 'number',
-            required: false,
-            default: 50,
-            
-            displayOptions: {
-              show: {
-                resource: ['webhooks'],
-                operation: ['deliveries'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'limit': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
-            displayName: 'Number of deliveries to skip',
-            name: 'offset',
-            type: 'number',
-            required: false,
-            default: "",
-            
-            displayOptions: {
-              show: {
-                resource: ['webhooks'],
-                operation: ['deliveries'],
-              },
-            },
-            routing: {
-              request: {
-                qs: {
-                  'offset': '={{$value}}',
-                },
-              },
-            },
-          },
-      {
           displayName: 'Project',
           name: 'project',
           type: 'string',
@@ -6611,18 +6368,93 @@ export class MsgCore implements INodeType {
           },
         },
       {
-          displayName: 'WebhookId',
+          displayName: 'Webhook Id',
           name: 'webhookId',
           type: 'string',
           required: true,
           default: '',
-          description: 'webhookId parameter',
+          description: 'Webhook Id parameter',
           displayOptions: {
             show: {
               resource: ['webhooks'],
               operation: ['deliveries'],
             },
           },
+        },
+      {
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['webhooks'],
+              operation: ['deliveries'],
+            },
+          },
+          options: [
+            {
+              displayName: 'Filter by event type',
+              name: 'event',
+              type: 'string',
+              default: "",
+              description: 'Filter by event type',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'event': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Filter by delivery status',
+              name: 'status',
+              type: 'string',
+              default: "",
+              description: 'Filter by delivery status',
+              options: [{name: 'pending', value: 'pending'}, {name: 'success', value: 'success'}, {name: 'failed', value: 'failed'}],
+              routing: {
+                request: {
+                  qs: {
+                    'status': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Number of deliveries to return (1-100)',
+              name: 'limit',
+              type: 'number',
+              default: 50,
+              description: 'Number of deliveries to return (1-100)',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'limit': '={{$value}}',
+                  },
+                },
+              },
+            },
+            {
+              displayName: 'Number of deliveries to skip',
+              name: 'offset',
+              type: 'number',
+              default: 0,
+              description: 'Number of deliveries to skip',
+              
+              routing: {
+                request: {
+                  qs: {
+                    'offset': '={{$value}}',
+                  },
+                },
+              },
+            }
+          ],
         }
     ],
   };

--- a/packages/n8n/package.json
+++ b/packages/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-msgcore",
-  "version": "1.1.0",
+  "version": "1.1.3",
   "description": "n8n community node for MsgCore universal messaging gateway",
   "keywords": [
     "n8n-community-node-package",

--- a/packages/openapi/openapi.json
+++ b/packages/openapi/openapi.json
@@ -3659,306 +3659,6 @@
         }
       }
     },
-    "/api/v1/billing/checkout": {
-      "post": {
-        "summary": "Create Stripe checkout session for subscription upgrade",
-        "description": "Create Stripe checkout session for subscription upgrade",
-        "operationId": "billingCheckout",
-        "tags": [
-          "Billing"
-        ],
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateCheckoutDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CheckoutResponseDto"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient permissions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/billing/portal": {
-      "post": {
-        "summary": "Access Stripe customer portal to manage subscription",
-        "description": "Access Stripe customer portal to manage subscription",
-        "operationId": "billingPortal",
-        "tags": [
-          "Billing"
-        ],
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PortalResponseDto"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient permissions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/billing/subscription": {
-      "get": {
-        "summary": "Get current subscription details including tier, status, and trial info",
-        "description": "Get current subscription details including tier, status, and trial info",
-        "operationId": "billingSubscription",
-        "tags": [
-          "Billing"
-        ],
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SubscriptionResponseDto"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient permissions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/billing/usage": {
-      "get": {
-        "summary": "Get usage statistics for projects, messages, platforms, webhooks with limit warnings",
-        "description": "Get usage statistics for projects, messages, platforms, webhooks with limit warnings",
-        "operationId": "billingUsage",
-        "tags": [
-          "Billing"
-        ],
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UsageResponseDto"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient permissions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/billing/sync": {
-      "post": {
-        "summary": "Manually sync subscription data from Stripe",
-        "description": "Manually sync subscription data from Stripe",
-        "operationId": "billingSync",
-        "tags": [
-          "Billing"
-        ],
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SyncResponseDto"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient permissions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/auth/signup": {
       "post": {
         "summary": "Create a new user account (first user becomes admin)",
@@ -4681,117 +4381,37 @@
         }
       }
     },
-    "/api/v1/projects/{project}/platforms/logs": {
-      "get": {
-        "summary": "List platform processing logs for a project",
-        "description": "List platform processing logs for a project",
-        "operationId": "platformsLogsList",
+    "/api/v1/billing/checkout": {
+      "post": {
+        "summary": "Create Stripe checkout session for subscription upgrade",
+        "description": "Create Stripe checkout session for subscription upgrade",
+        "operationId": "billingCheckout",
         "tags": [
-          "Platform Logs"
+          "Billing"
         ],
         "security": [
           {
-            "ApiKeyAuth": [
-              "platforms:read"
-            ]
+            "ApiKeyAuth": []
           }
         ],
-        "parameters": [
-          {
-            "name": "project",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "project parameter"
-          },
-          {
-            "name": "platform",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Filter by platform (telegram, discord)"
-          },
-          {
-            "name": "level",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "info",
-                "warn",
-                "error",
-                "debug"
-              ]
-            },
-            "description": "Filter by log level"
-          },
-          {
-            "name": "category",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "connection",
-                "webhook",
-                "message",
-                "error",
-                "auth",
-                "general"
-              ]
-            },
-            "description": "Filter by log category"
-          },
-          {
-            "name": "startDate",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Filter logs after this date (ISO 8601)"
-          },
-          {
-            "name": "endDate",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Filter logs before this date (ISO 8601)"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "number",
-              "default": "100"
-            },
-            "description": "Number of logs to return (1-1000)"
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "number"
-            },
-            "description": "Number of logs to skip"
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCheckoutDto"
+              }
+            }
           }
-        ],
+        },
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PlatformLogsResponse"
+                  "$ref": "#/components/schemas/CheckoutResponseDto"
                 }
               }
             }
@@ -4829,231 +4449,13 @@
         }
       }
     },
-    "/api/v1/projects/{project}/platforms/{platformId}/logs": {
-      "get": {
-        "summary": "List logs for a specific platform configuration",
-        "description": "List logs for a specific platform configuration",
-        "operationId": "platformsLogsGet",
+    "/api/v1/billing/portal": {
+      "post": {
+        "summary": "Access Stripe customer portal to manage subscription",
+        "description": "Access Stripe customer portal to manage subscription",
+        "operationId": "billingPortal",
         "tags": [
-          "Platform Logs"
-        ],
-        "security": [
-          {
-            "ApiKeyAuth": [
-              "platforms:read"
-            ]
-          }
-        ],
-        "parameters": [
-          {
-            "name": "project",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "project parameter"
-          },
-          {
-            "name": "platformId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "platformId parameter"
-          },
-          {
-            "name": "level",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "info",
-                "warn",
-                "error",
-                "debug"
-              ]
-            },
-            "description": "Filter by log level"
-          },
-          {
-            "name": "category",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "connection",
-                "webhook",
-                "message",
-                "error",
-                "auth",
-                "general"
-              ]
-            },
-            "description": "Filter by log category"
-          },
-          {
-            "name": "startDate",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Filter logs after this date (ISO 8601)"
-          },
-          {
-            "name": "endDate",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Filter logs before this date (ISO 8601)"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "number",
-              "default": "100"
-            },
-            "description": "Number of logs to return (1-1000)"
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "number"
-            },
-            "description": "Number of logs to skip"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformLogsResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient permissions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/projects/{project}/platforms/logs/stats": {
-      "get": {
-        "summary": "Get platform logs statistics and recent errors",
-        "description": "Get platform logs statistics and recent errors",
-        "operationId": "platformsLogsStats",
-        "tags": [
-          "Platform Logs"
-        ],
-        "security": [
-          {
-            "ApiKeyAuth": [
-              "platforms:read"
-            ]
-          }
-        ],
-        "parameters": [
-          {
-            "name": "project",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "project parameter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlatformLogStatsResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient permissions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/platforms/supported": {
-      "get": {
-        "summary": "List supported platforms with credential requirements",
-        "description": "List supported platforms with credential requirements",
-        "operationId": "platformsSupported",
-        "tags": [
-          "Platforms"
+          "Billing"
         ],
         "security": [
           {
@@ -5067,7 +4469,181 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SupportedPlatformsResponse"
+                  "$ref": "#/components/schemas/PortalResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/billing/subscription": {
+      "get": {
+        "summary": "Get current subscription details including tier, status, and trial info",
+        "description": "Get current subscription details including tier, status, and trial info",
+        "operationId": "billingSubscription",
+        "tags": [
+          "Billing"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/billing/usage": {
+      "get": {
+        "summary": "Get usage statistics for projects, messages, platforms, webhooks with limit warnings",
+        "description": "Get usage statistics for projects, messages, platforms, webhooks with limit warnings",
+        "operationId": "billingUsage",
+        "tags": [
+          "Billing"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UsageResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/billing/sync": {
+      "post": {
+        "summary": "Manually sync subscription data from Stripe",
+        "description": "Manually sync subscription data from Stripe",
+        "operationId": "billingSync",
+        "tags": [
+          "Billing"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncResponseDto"
                 }
               }
             }
@@ -5588,6 +5164,430 @@
               "application/json": {
                 "schema": {
                   "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{project}/platforms/logs": {
+      "get": {
+        "summary": "List platform processing logs for a project",
+        "description": "List platform processing logs for a project",
+        "operationId": "platformsLogsList",
+        "tags": [
+          "Platform Logs"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": [
+              "platforms:read"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "project parameter"
+          },
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by platform (telegram, discord)"
+          },
+          {
+            "name": "level",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "info",
+                "warn",
+                "error",
+                "debug"
+              ]
+            },
+            "description": "Filter by log level"
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "connection",
+                "webhook",
+                "message",
+                "error",
+                "auth",
+                "general"
+              ]
+            },
+            "description": "Filter by log category"
+          },
+          {
+            "name": "startDate",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter logs after this date (ISO 8601)"
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter logs before this date (ISO 8601)"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "default": "100"
+            },
+            "description": "Number of logs to return (1-1000)"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number"
+            },
+            "description": "Number of logs to skip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformLogsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{project}/platforms/{platformId}/logs": {
+      "get": {
+        "summary": "List logs for a specific platform configuration",
+        "description": "List logs for a specific platform configuration",
+        "operationId": "platformsLogsGet",
+        "tags": [
+          "Platform Logs"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": [
+              "platforms:read"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "project parameter"
+          },
+          {
+            "name": "platformId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "platformId parameter"
+          },
+          {
+            "name": "level",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "info",
+                "warn",
+                "error",
+                "debug"
+              ]
+            },
+            "description": "Filter by log level"
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "connection",
+                "webhook",
+                "message",
+                "error",
+                "auth",
+                "general"
+              ]
+            },
+            "description": "Filter by log category"
+          },
+          {
+            "name": "startDate",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter logs after this date (ISO 8601)"
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter logs before this date (ISO 8601)"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "default": "100"
+            },
+            "description": "Number of logs to return (1-1000)"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number"
+            },
+            "description": "Number of logs to skip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformLogsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{project}/platforms/logs/stats": {
+      "get": {
+        "summary": "Get platform logs statistics and recent errors",
+        "description": "Get platform logs statistics and recent errors",
+        "operationId": "platformsLogsStats",
+        "tags": [
+          "Platform Logs"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": [
+              "platforms:read"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "project parameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlatformLogStatsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/platforms/supported": {
+      "get": {
+        "summary": "List supported platforms with credential requirements",
+        "description": "List supported platforms with credential requirements",
+        "operationId": "platformsSupported",
+        "tags": [
+          "Platforms"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportedPlatformsResponse"
                 }
               }
             }

--- a/packages/openapi/openapi.yaml
+++ b/packages/openapi/openapi.yaml
@@ -2365,192 +2365,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/billing/checkout:
-    post:
-      summary: "Create Stripe checkout session for subscription upgrade"
-      description: "Create Stripe checkout session for subscription upgrade"
-      operationId: "billingCheckout"
-      tags:
-        - "Billing"
-      security:
-        -
-          ApiKeyAuth:
-      parameters:
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreateCheckoutDto"
-      responses:
-        200:
-          description: "Successful response"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CheckoutResponseDto"
-        401:
-          description: "Authentication required"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        403:
-          description: "Insufficient permissions"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        404:
-          description: "Resource not found"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/billing/portal:
-    post:
-      summary: "Access Stripe customer portal to manage subscription"
-      description: "Access Stripe customer portal to manage subscription"
-      operationId: "billingPortal"
-      tags:
-        - "Billing"
-      security:
-        -
-          ApiKeyAuth:
-      parameters:
-      responses:
-        200:
-          description: "Successful response"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PortalResponseDto"
-        401:
-          description: "Authentication required"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        403:
-          description: "Insufficient permissions"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        404:
-          description: "Resource not found"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/billing/subscription:
-    get:
-      summary: "Get current subscription details including tier, status, and trial info"
-      description: "Get current subscription details including tier, status, and trial info"
-      operationId: "billingSubscription"
-      tags:
-        - "Billing"
-      security:
-        -
-          ApiKeyAuth:
-      parameters:
-      responses:
-        200:
-          description: "Successful response"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SubscriptionResponseDto"
-        401:
-          description: "Authentication required"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        403:
-          description: "Insufficient permissions"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        404:
-          description: "Resource not found"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/billing/usage:
-    get:
-      summary: "Get usage statistics for projects, messages, platforms, webhooks with limit warnings"
-      description: "Get usage statistics for projects, messages, platforms, webhooks with limit warnings"
-      operationId: "billingUsage"
-      tags:
-        - "Billing"
-      security:
-        -
-          ApiKeyAuth:
-      parameters:
-      responses:
-        200:
-          description: "Successful response"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/UsageResponseDto"
-        401:
-          description: "Authentication required"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        403:
-          description: "Insufficient permissions"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        404:
-          description: "Resource not found"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/billing/sync:
-    post:
-      summary: "Manually sync subscription data from Stripe"
-      description: "Manually sync subscription data from Stripe"
-      operationId: "billingSync"
-      tags:
-        - "Billing"
-      security:
-        -
-          ApiKeyAuth:
-      parameters:
-      responses:
-        200:
-          description: "Successful response"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SyncResponseDto"
-        401:
-          description: "Authentication required"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        403:
-          description: "Insufficient permissions"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        404:
-          description: "Resource not found"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
   /api/v1/auth/signup:
     post:
       summary: "Create a new user account (first user becomes admin)"
@@ -3006,94 +2820,30 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/projects/{project}/platforms/logs:
-    get:
-      summary: "List platform processing logs for a project"
-      description: "List platform processing logs for a project"
-      operationId: "platformsLogsList"
+  /api/v1/billing/checkout:
+    post:
+      summary: "Create Stripe checkout session for subscription upgrade"
+      description: "Create Stripe checkout session for subscription upgrade"
+      operationId: "billingCheckout"
       tags:
-        - "Platform Logs"
+        - "Billing"
       security:
         -
           ApiKeyAuth:
-            - "platforms:read"
       parameters:
-        -
-          name: "project"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
-          description: "project parameter"
-        -
-          name: "platform"
-          in: "query"
-          required: false
-          schema:
-            type: "string"
-          description: "Filter by platform (telegram, discord)"
-        -
-          name: "level"
-          in: "query"
-          required: false
-          schema:
-            type: "string"
-            enum:
-              - "info"
-              - "warn"
-              - "error"
-              - "debug"
-          description: "Filter by log level"
-        -
-          name: "category"
-          in: "query"
-          required: false
-          schema:
-            type: "string"
-            enum:
-              - "connection"
-              - "webhook"
-              - "message"
-              - "error"
-              - "auth"
-              - "general"
-          description: "Filter by log category"
-        -
-          name: "startDate"
-          in: "query"
-          required: false
-          schema:
-            type: "string"
-          description: "Filter logs after this date (ISO 8601)"
-        -
-          name: "endDate"
-          in: "query"
-          required: false
-          schema:
-            type: "string"
-          description: "Filter logs before this date (ISO 8601)"
-        -
-          name: "limit"
-          in: "query"
-          required: false
-          schema:
-            type: "number"
-            default: "100"
-          description: "Number of logs to return (1-1000)"
-        -
-          name: "offset"
-          in: "query"
-          required: false
-          schema:
-            type: "number"
-          description: "Number of logs to skip"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateCheckoutDto"
       responses:
         200:
           description: "Successful response"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PlatformLogsResponse"
+                $ref: "#/components/schemas/CheckoutResponseDto"
         401:
           description: "Authentication required"
           content:
@@ -3112,94 +2862,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/projects/{project}/platforms/{platformId}/logs:
-    get:
-      summary: "List logs for a specific platform configuration"
-      description: "List logs for a specific platform configuration"
-      operationId: "platformsLogsGet"
+  /api/v1/billing/portal:
+    post:
+      summary: "Access Stripe customer portal to manage subscription"
+      description: "Access Stripe customer portal to manage subscription"
+      operationId: "billingPortal"
       tags:
-        - "Platform Logs"
+        - "Billing"
       security:
         -
           ApiKeyAuth:
-            - "platforms:read"
       parameters:
-        -
-          name: "project"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
-          description: "project parameter"
-        -
-          name: "platformId"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
-          description: "platformId parameter"
-        -
-          name: "level"
-          in: "query"
-          required: false
-          schema:
-            type: "string"
-            enum:
-              - "info"
-              - "warn"
-              - "error"
-              - "debug"
-          description: "Filter by log level"
-        -
-          name: "category"
-          in: "query"
-          required: false
-          schema:
-            type: "string"
-            enum:
-              - "connection"
-              - "webhook"
-              - "message"
-              - "error"
-              - "auth"
-              - "general"
-          description: "Filter by log category"
-        -
-          name: "startDate"
-          in: "query"
-          required: false
-          schema:
-            type: "string"
-          description: "Filter logs after this date (ISO 8601)"
-        -
-          name: "endDate"
-          in: "query"
-          required: false
-          schema:
-            type: "string"
-          description: "Filter logs before this date (ISO 8601)"
-        -
-          name: "limit"
-          in: "query"
-          required: false
-          schema:
-            type: "number"
-            default: "100"
-          description: "Number of logs to return (1-1000)"
-        -
-          name: "offset"
-          in: "query"
-          required: false
-          schema:
-            type: "number"
-          description: "Number of logs to skip"
       responses:
         200:
           description: "Successful response"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PlatformLogsResponse"
+                $ref: "#/components/schemas/PortalResponseDto"
         401:
           description: "Authentication required"
           content:
@@ -3218,32 +2898,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/projects/{project}/platforms/logs/stats:
+  /api/v1/billing/subscription:
     get:
-      summary: "Get platform logs statistics and recent errors"
-      description: "Get platform logs statistics and recent errors"
-      operationId: "platformsLogsStats"
+      summary: "Get current subscription details including tier, status, and trial info"
+      description: "Get current subscription details including tier, status, and trial info"
+      operationId: "billingSubscription"
       tags:
-        - "Platform Logs"
+        - "Billing"
       security:
         -
           ApiKeyAuth:
-            - "platforms:read"
       parameters:
-        -
-          name: "project"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
-          description: "project parameter"
       responses:
         200:
           description: "Successful response"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PlatformLogStatsResponse"
+                $ref: "#/components/schemas/SubscriptionResponseDto"
         401:
           description: "Authentication required"
           content:
@@ -3262,13 +2934,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  /api/v1/platforms/supported:
+  /api/v1/billing/usage:
     get:
-      summary: "List supported platforms with credential requirements"
-      description: "List supported platforms with credential requirements"
-      operationId: "platformsSupported"
+      summary: "Get usage statistics for projects, messages, platforms, webhooks with limit warnings"
+      description: "Get usage statistics for projects, messages, platforms, webhooks with limit warnings"
+      operationId: "billingUsage"
       tags:
-        - "Platforms"
+        - "Billing"
       security:
         -
           ApiKeyAuth:
@@ -3279,7 +2951,43 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SupportedPlatformsResponse"
+                $ref: "#/components/schemas/UsageResponseDto"
+        401:
+          description: "Authentication required"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        403:
+          description: "Insufficient permissions"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: "Resource not found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/billing/sync:
+    post:
+      summary: "Manually sync subscription data from Stripe"
+      description: "Manually sync subscription data from Stripe"
+      operationId: "billingSync"
+      tags:
+        - "Billing"
+      security:
+        -
+          ApiKeyAuth:
+      parameters:
+      responses:
+        200:
+          description: "Successful response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SyncResponseDto"
         401:
           description: "Authentication required"
           content:
@@ -3619,6 +3327,298 @@ paths:
             application/json:
               schema:
                 type: "object"
+        401:
+          description: "Authentication required"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        403:
+          description: "Insufficient permissions"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: "Resource not found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/projects/{project}/platforms/logs:
+    get:
+      summary: "List platform processing logs for a project"
+      description: "List platform processing logs for a project"
+      operationId: "platformsLogsList"
+      tags:
+        - "Platform Logs"
+      security:
+        -
+          ApiKeyAuth:
+            - "platforms:read"
+      parameters:
+        -
+          name: "project"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+          description: "project parameter"
+        -
+          name: "platform"
+          in: "query"
+          required: false
+          schema:
+            type: "string"
+          description: "Filter by platform (telegram, discord)"
+        -
+          name: "level"
+          in: "query"
+          required: false
+          schema:
+            type: "string"
+            enum:
+              - "info"
+              - "warn"
+              - "error"
+              - "debug"
+          description: "Filter by log level"
+        -
+          name: "category"
+          in: "query"
+          required: false
+          schema:
+            type: "string"
+            enum:
+              - "connection"
+              - "webhook"
+              - "message"
+              - "error"
+              - "auth"
+              - "general"
+          description: "Filter by log category"
+        -
+          name: "startDate"
+          in: "query"
+          required: false
+          schema:
+            type: "string"
+          description: "Filter logs after this date (ISO 8601)"
+        -
+          name: "endDate"
+          in: "query"
+          required: false
+          schema:
+            type: "string"
+          description: "Filter logs before this date (ISO 8601)"
+        -
+          name: "limit"
+          in: "query"
+          required: false
+          schema:
+            type: "number"
+            default: "100"
+          description: "Number of logs to return (1-1000)"
+        -
+          name: "offset"
+          in: "query"
+          required: false
+          schema:
+            type: "number"
+          description: "Number of logs to skip"
+      responses:
+        200:
+          description: "Successful response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformLogsResponse"
+        401:
+          description: "Authentication required"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        403:
+          description: "Insufficient permissions"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: "Resource not found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/projects/{project}/platforms/{platformId}/logs:
+    get:
+      summary: "List logs for a specific platform configuration"
+      description: "List logs for a specific platform configuration"
+      operationId: "platformsLogsGet"
+      tags:
+        - "Platform Logs"
+      security:
+        -
+          ApiKeyAuth:
+            - "platforms:read"
+      parameters:
+        -
+          name: "project"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+          description: "project parameter"
+        -
+          name: "platformId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+          description: "platformId parameter"
+        -
+          name: "level"
+          in: "query"
+          required: false
+          schema:
+            type: "string"
+            enum:
+              - "info"
+              - "warn"
+              - "error"
+              - "debug"
+          description: "Filter by log level"
+        -
+          name: "category"
+          in: "query"
+          required: false
+          schema:
+            type: "string"
+            enum:
+              - "connection"
+              - "webhook"
+              - "message"
+              - "error"
+              - "auth"
+              - "general"
+          description: "Filter by log category"
+        -
+          name: "startDate"
+          in: "query"
+          required: false
+          schema:
+            type: "string"
+          description: "Filter logs after this date (ISO 8601)"
+        -
+          name: "endDate"
+          in: "query"
+          required: false
+          schema:
+            type: "string"
+          description: "Filter logs before this date (ISO 8601)"
+        -
+          name: "limit"
+          in: "query"
+          required: false
+          schema:
+            type: "number"
+            default: "100"
+          description: "Number of logs to return (1-1000)"
+        -
+          name: "offset"
+          in: "query"
+          required: false
+          schema:
+            type: "number"
+          description: "Number of logs to skip"
+      responses:
+        200:
+          description: "Successful response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformLogsResponse"
+        401:
+          description: "Authentication required"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        403:
+          description: "Insufficient permissions"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: "Resource not found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/projects/{project}/platforms/logs/stats:
+    get:
+      summary: "Get platform logs statistics and recent errors"
+      description: "Get platform logs statistics and recent errors"
+      operationId: "platformsLogsStats"
+      tags:
+        - "Platform Logs"
+      security:
+        -
+          ApiKeyAuth:
+            - "platforms:read"
+      parameters:
+        -
+          name: "project"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+          description: "project parameter"
+      responses:
+        200:
+          description: "Successful response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformLogStatsResponse"
+        401:
+          description: "Authentication required"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        403:
+          description: "Insufficient permissions"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        404:
+          description: "Resource not found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/v1/platforms/supported:
+    get:
+      summary: "List supported platforms with credential requirements"
+      description: "List supported platforms with credential requirements"
+      operationId: "platformsSupported"
+      tags:
+        - "Platforms"
+      security:
+        -
+          ApiKeyAuth:
+      parameters:
+      responses:
+        200:
+          description: "Successful response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SupportedPlatformsResponse"
         401:
           description: "Authentication required"
           content:

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msgcore/sdk",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Official TypeScript SDK for MsgCore universal messaging gateway",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -6,6 +6,6 @@ export * from './types.js';
 export * from './errors.js';
 
 // Version info
-export const SDK_VERSION = '1.1.0';
-export const GENERATED_AT = '2025-11-30T15:06:28.849Z';
+export const SDK_VERSION = '1.1.2';
+export const GENERATED_AT = '2025-12-29T14:27:48.662Z';
 export const CONTRACTS_COUNT = 87;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -593,8 +593,9 @@ export interface ResourceUsage {
 }
 
 export interface SendMessageDto {
-  targets: TargetDto[];
-  content: ContentDto;
+  target: string;
+  text?: string;
+  content?: ContentDto;
   options?: OptionsDto;
   metadata?: MetadataDto;
 }
@@ -658,14 +659,6 @@ export interface SyncHistoryDto {
 export interface SyncResponseDto {
   synced: boolean;
 }
-
-export interface TargetDto {
-  platformId: string;
-  type: TargetType;
-  id: string;
-}
-
-export type TargetType = 'chat' | 'identity' | 'messages' | 'date_range';
 
 export interface UpdateAnalysisProfileDto {
   name?: string;

--- a/src/messages/messages.controller.ts
+++ b/src/messages/messages.controller.ts
@@ -220,24 +220,20 @@ export class MessagesController {
     outputType: 'MessageSendResponse',
     options: {
       target: {
-        description: 'Single target in format: platformId:type:id',
-        type: 'target_pattern',
-      },
-      targets: {
-        description:
-          'Multiple targets comma-separated: platformId:type:id,platformId:type:id',
-        type: 'targets_pattern',
+        required: true,
+        description: 'Target(s) in format platformId:type:id. For multiple, comma-separate: p1:user:1,p2:channel:2',
+        type: 'string',
       },
       text: {
         description: 'Message text content',
         type: 'string',
       },
       content: {
-        description: 'Full message content object (advanced)',
+        description: 'Full content object (text, markdown, html, attachments, buttons, embeds)',
         type: 'object',
       },
-      options: { description: 'Message options', type: 'object' },
-      metadata: { description: 'Message metadata', type: 'object' },
+      options: { description: 'Message options (replyTo, silent, scheduled)', type: 'object' },
+      metadata: { description: 'Message metadata (trackingId, tags, priority)', type: 'object' },
     },
     examples: [
       {
@@ -248,7 +244,7 @@ export class MessagesController {
       {
         description: 'Send to multiple targets',
         command:
-          'msgcore messages send --targets "platform1:user:123,platform2:channel:456" --text "Broadcast message"',
+          'msgcore messages send --target "platform1:user:123,platform2:channel:456" --text "Broadcast message"',
       },
       {
         description: 'Advanced with full content object',

--- a/src/platforms/dto/send-message.dto.ts
+++ b/src/platforms/dto/send-message.dto.ts
@@ -230,14 +230,17 @@ export class MetadataDto {
 }
 
 export class SendMessageDto {
-  @IsArray()
-  @ValidateNested({ each: true })
-  @Type(() => TargetDto)
-  targets: TargetDto[];
+  @IsString()
+  target: string; // Format: "platformId:type:id" or comma-separated "p1:user:1,p2:channel:2"
 
+  @IsOptional()
+  @IsString()
+  text?: string; // Simple text shortcut
+
+  @IsOptional()
   @ValidateNested()
   @Type(() => ContentDto)
-  content: ContentDto;
+  content?: ContentDto; // Full content object (advanced)
 
   @IsOptional()
   @ValidateNested()

--- a/src/platforms/messages/messages.service.ts
+++ b/src/platforms/messages/messages.service.ts
@@ -38,31 +38,30 @@ export class MessagesService {
   ) {}
 
   async sendMessage(projectId: string, sendMessageDto: SendMessageDto, authContext: AuthContext) {
-    const targetCount = sendMessageDto.targets.length;
-    const platformIds = sendMessageDto.targets.map((t) => t.platformId);
+    // Parse and validate targets
+    const parsedTargets = this.parseTargetString(sendMessageDto.target);
+    const targetCount = parsedTargets.length;
+    const platformIds = parsedTargets.map((t) => t.platformId);
 
-    this.logger.log(`Sending message to ${targetCount} targets`);
+    this.logger.log(`Sending message to ${targetCount} target(s)`);
 
-    // Get project and validate platforms
+    // Get project
     const project = await this.getProject(projectId);
 
     // BILLING: Check message limits and increment counter
     // Only check for JWT users (not API keys, as API keys are project-scoped)
     if (authContext.authType === 'jwt' && authContext.user?.userId) {
-      // Check if user has exceeded their message limit (throws PaymentRequiredException)
       await this.usageTracker.checkMessageLimit(authContext.user.userId);
-
-      // Increment message counter
       await this.usageTracker.incrementMessageCount(authContext.user.userId);
-
       this.logger.log(`Message limit checked and counter incremented for user ${authContext.user.userId}`);
     }
 
-    for (const target of sendMessageDto.targets) {
+    // Validate all platform IDs exist
+    for (const target of parsedTargets) {
       await this.platformsService.validatePlatformConfigById(target.platformId);
     }
 
-    // Queue message for processing
+    // Queue message for processing (pass DTO directly)
     const queueResult = await this.messageQueue.addMessage({
       projectId: project.id,
       message: sendMessageDto,
@@ -70,16 +69,45 @@ export class MessagesService {
 
     this.logger.log(`Message queued - Job ID: ${queueResult.jobId}`);
 
-    const response = {
+    return {
       success: true,
       jobId: queueResult.jobId,
       status: queueResult.status,
-      targets: sendMessageDto.targets,
+      target: sendMessageDto.target,
       platformIds,
       timestamp: new Date().toISOString(),
       message: 'Message queued for delivery',
     };
-    return response;
+  }
+
+  /**
+   * Parse target string for validation
+   * Format: "platformId:type:id" or comma-separated "p1:user:1,p2:channel:2"
+   */
+  parseTargetString(targetString: string): Array<{ platformId: string; type: string; id: string }> {
+    const validTypes = ['user', 'channel', 'group'];
+    const targetParts = targetString.split(',').map(s => s.trim()).filter(s => s);
+
+    return targetParts.map(part => {
+      const segments = part.split(':');
+      if (segments.length < 3) {
+        throw new BadRequestException(
+          `Invalid target format: "${part}". Expected "platformId:type:id" (e.g., "abc123:user:456")`,
+        );
+      }
+
+      const platformId = segments[0];
+      const typeStr = segments[1].toLowerCase();
+      const id = segments.slice(2).join(':'); // Join remaining parts in case id contains colons
+
+      if (!validTypes.includes(typeStr)) {
+        throw new BadRequestException(
+          `Invalid target type: "${typeStr}". Expected one of: user, channel, group`,
+        );
+      }
+
+      return { platformId, type: typeStr, id };
+    });
   }
 
   async getMessageStatus(jobId: string) {

--- a/src/queues/message.queue.ts
+++ b/src/queues/message.queue.ts
@@ -33,9 +33,9 @@ export class MessageQueue implements OnModuleInit, OnModuleDestroy {
   async addMessage(data: MessageJobData) {
     const job = await this.messageQueue.add('send-message', data);
 
-    const platformIds = data.message.targets.map((t) => t.platformId);
+    const targetCount = data.message.target.split(',').length;
     this.logger.log(
-      `Message queued for ${data.message.targets.length} targets (Job ID: ${job.id})`,
+      `Message queued for ${targetCount} target(s) (Job ID: ${job.id})`,
     );
 
     return {

--- a/src/queues/processors/dynamic-message.processor.ts
+++ b/src/queues/processors/dynamic-message.processor.ts
@@ -19,15 +19,13 @@ import { CryptoUtil } from '../../common/utils/crypto.util';
 import { WebhookDeliveryService } from '../../webhooks/services/webhook-delivery.service';
 import { WebhookEventType } from '../../webhooks/types/webhook-event.types';
 
+// Matches SendMessageDto from API
 interface MessageJob {
   projectId: string;
   message: {
-    targets: Array<{
-      platformId: string;
-      type: string;
-      id: string;
-    }>;
-    content: {
+    target: string; // Format: "platformId:type:id" or comma-separated
+    text?: string;  // Simple text shortcut
+    content?: {
       subject?: string;
       text?: string;
       markdown?: string;
@@ -48,6 +46,12 @@ interface MessageJob {
       priority?: string;
     };
   };
+}
+
+interface ParsedTarget {
+  platformId: string;
+  type: string;
+  id: string;
 }
 
 @Injectable()
@@ -76,12 +80,20 @@ export class DynamicMessageProcessor
   async process(job: Job<MessageJob>) {
     const { projectId, message } = job.data;
 
+    // Parse target string into array
+    const parsedTargets = this.parseTargetString(message.target);
+
+    // Build content from text shortcut or content object
+    const content = message.content || {};
+    if (message.text && !content.text) {
+      content.text = message.text;
+    }
+
     // SECURITY: Deduplicate targets to prevent spam attacks
-    const targetMap = new Map<string, (typeof message.targets)[0]>();
+    const targetMap = new Map<string, ParsedTarget>();
     const duplicatesDetected: string[] = [];
 
-    for (const target of message.targets) {
-      // SECURITY: Safe key generation that handles special characters
+    for (const target of parsedTargets) {
       const targetKey = this.generateSafeTargetKey(target);
 
       if (!targetMap.has(targetKey)) {
@@ -95,7 +107,7 @@ export class DynamicMessageProcessor
     }
 
     const uniqueTargets = Array.from(targetMap.values());
-    const originalCount = message.targets.length;
+    const originalCount = parsedTargets.length;
     const deduplicatedCount = uniqueTargets.length;
 
     if (duplicatesDetected.length > 0) {
@@ -202,8 +214,8 @@ export class DynamicMessageProcessor
             jobId: job.id?.toString(),
             providerChatId: target.id,
             providerUserId: target.type === 'user' ? target.id : 'system',
-            messageText: message.content.text || null,
-            messageContent: message.content,
+            messageText: content.text || null,
+            messageContent: content,
             status: MessageStatus.queued,
           },
         });
@@ -236,7 +248,7 @@ export class DynamicMessageProcessor
             display: 'System',
           },
           message: {
-            text: message.content.text,
+            text: content.text,
           },
           provider: {
             eventId: `job-${job.id}-${platformConfig.platform}-${target.id}`,
@@ -249,14 +261,14 @@ export class DynamicMessageProcessor
 
         // Send the message through the adapter
         const result = await adapter.sendMessage(envelope, {
-          subject: message.content.subject,
-          text: message.content.text,
-          markdown: message.content.markdown,
-          html: message.content.html,
-          attachments: message.content.attachments,
-          buttons: message.content.buttons,
-          embeds: message.content.embeds,
-          platformOptions: message.content.platformOptions,
+          subject: content.subject,
+          text: content.text,
+          markdown: content.markdown,
+          html: content.html,
+          attachments: content.attachments,
+          buttons: content.buttons,
+          embeds: content.embeds,
+          platformOptions: content.platformOptions,
           threadId: target.id,
           replyTo: message.options?.replyTo,
           silent: message.options?.silent,
@@ -455,6 +467,29 @@ export class DynamicMessageProcessor
     }
 
     this.logger.log('Message processor cleanup complete');
+  }
+
+  /**
+   * Parse target string into array of ParsedTarget
+   * Format: "platformId:type:id" or comma-separated "p1:user:1,p2:channel:2"
+   */
+  private parseTargetString(targetString: string): ParsedTarget[] {
+    const targetParts = targetString.split(',').map(s => s.trim()).filter(s => s);
+
+    return targetParts.map(part => {
+      const segments = part.split(':');
+      if (segments.length < 3) {
+        throw new Error(
+          `Invalid target format: "${part}". Expected "platformId:type:id"`,
+        );
+      }
+
+      return {
+        platformId: segments[0],
+        type: segments[1].toLowerCase(),
+        id: segments.slice(2).join(':'), // Handle IDs with colons
+      };
+    });
   }
 
   /**

--- a/tools/generators/n8n-generator.ts
+++ b/tools/generators/n8n-generator.ts
@@ -455,21 +455,47 @@ export class MsgCore implements INodeType {
       const operation = contractMetadata.command.split(' ')[1];
       const category = contractMetadata.category?.toLowerCase() || 'general';
 
-      // Add parameters for this operation
+      // Collect required and optional parameters separately
+      const requiredParams: string[] = [];
+      const optionalParams: string[] = [];
+
+      // Determine routing type based on HTTP method
+      // POST/PUT/PATCH use body, GET/DELETE use query string
+      const httpMethod = contract.httpMethod.toUpperCase();
+      const usesBody = ['POST', 'PUT', 'PATCH'].includes(httpMethod);
+
+      // Process options from contract metadata
       if (contractMetadata.options) {
         Object.entries(contractMetadata.options).forEach(
           ([optionName, optionConfig]) => {
             const paramType = this.getN8NParameterType(
               optionConfig.type || 'string',
             );
+            const isRequired = optionConfig.required || false;
 
-            parameters.push(`{
-            displayName: '${optionConfig.description || optionName}',
-            name: '${optionName}',
-            type: '${paramType}',
-            required: ${optionConfig.required || false},
-            default: ${JSON.stringify(optionConfig.default || '')},
-            ${optionConfig.choices ? `options: [${optionConfig.choices.map((choice) => `{name: '${choice}', value: '${choice}'}`).join(', ')}],` : ''}
+            // For body-based methods, all params go in body
+            // For query-based methods, only json types go in body (rare)
+            const routingType = usesBody ? 'body' : (paramType === 'json' ? 'body' : 'qs');
+
+            const paramDef = {
+              displayName: optionConfig.description || this.formatDisplayName(optionName),
+              name: optionName,
+              type: paramType,
+              default: optionConfig.default ?? (paramType === 'number' ? 0 : ''),
+              description: optionConfig.description || `${this.formatDisplayName(optionName)} parameter`,
+              choices: optionConfig.choices,
+              routingType,
+            };
+
+            if (isRequired) {
+              // Required parameters are top-level
+              requiredParams.push(`{
+            displayName: '${paramDef.displayName}',
+            name: '${paramDef.name}',
+            type: '${paramDef.type}',
+            required: true,
+            default: ${JSON.stringify(paramDef.default)},
+            ${paramDef.choices ? `options: [${paramDef.choices.map((choice) => `{name: '${choice}', value: '${choice}'}`).join(', ')}],` : ''}
             displayOptions: {
               show: {
                 resource: ['${category}'],
@@ -478,30 +504,48 @@ export class MsgCore implements INodeType {
             },
             routing: {
               request: {
-                ${paramType === 'json' ? 'body' : 'qs'}: {
-                  '${optionName}': '={{$value}}',
+                ${paramDef.routingType}: {
+                  '${paramDef.name}': '={{$value}}',
                 },
               },
             },
           }`);
+            } else {
+              // Optional parameters go into additionalFields
+              optionalParams.push(`{
+              displayName: '${paramDef.displayName}',
+              name: '${paramDef.name}',
+              type: '${paramDef.type}',
+              default: ${JSON.stringify(paramDef.default)},
+              description: '${paramDef.description}',
+              ${paramDef.choices ? `options: [${paramDef.choices.map((choice) => `{name: '${choice}', value: '${choice}'}`).join(', ')}],` : ''}
+              routing: {
+                request: {
+                  ${paramDef.routingType}: {
+                    '${paramDef.name}': '={{$value}}',
+                  },
+                },
+              },
+            }`);
+            }
           },
         );
       }
 
-      // Add path parameters (including project as parameter, not credential)
+      // Add path parameters (always required, top-level)
       const pathParams = this.extractPathParameters(contract.path);
       pathParams.forEach((param) => {
         const displayName =
           param === 'project'
             ? 'Project'
-            : param.charAt(0).toUpperCase() + param.slice(1);
+            : this.formatDisplayName(param);
         const description =
           param === 'project'
             ? 'Project identifier to operate on'
-            : `${param} parameter`;
+            : `${this.formatDisplayName(param)} parameter`;
         const defaultValue = param === 'project' ? 'default' : '';
 
-        parameters.push(`{
+        requiredParams.push(`{
           displayName: '${displayName}',
           name: '${param}',
           type: 'string',
@@ -516,9 +560,40 @@ export class MsgCore implements INodeType {
           },
         }`);
       });
+
+      // Add required parameters to the list
+      parameters.push(...requiredParams);
+
+      // If there are optional parameters, create an additionalFields collection
+      if (optionalParams.length > 0) {
+        parameters.push(`{
+          displayName: 'Additional Fields',
+          name: 'additionalFields',
+          type: 'collection',
+          placeholder: 'Add Field',
+          default: {},
+          displayOptions: {
+            show: {
+              resource: ['${category}'],
+              operation: ['${operation}'],
+            },
+          },
+          options: [
+            ${optionalParams.join(',\n            ')}
+          ],
+        }`);
+      }
     });
 
     return parameters.join(',\n      ');
+  }
+
+  private formatDisplayName(name: string): string {
+    // Convert camelCase to Title Case with spaces
+    return name
+      .replace(/([A-Z])/g, ' $1')
+      .replace(/^./, (str) => str.toUpperCase())
+      .trim();
   }
 
   private generateCredentialsFile(): string {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -55,7 +55,7 @@
     },
     "../packages/sdk": {
       "name": "@msgcore/sdk",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.12.2"


### PR DESCRIPTION
## Summary
- Replace `targets` array with simple `target` string format
- Add `text` shortcut field for simple text messages
- Update n8n generator to use `additionalFields` for optional params
- Fix n8n routing to use `body` for POST/PUT/PATCH requests

## Breaking Change
`SendMessageDto` now uses `target` string instead of `targets` array. The new format matches CLI behavior exactly.

**Before:**
```json
{
  "targets": [{ "platformId": "abc", "type": "user", "id": "123" }],
  "content": { "text": "Hello" }
}
```

**After:**
```json
{
  "target": "abc:user:123",
  "text": "Hello"
}
```

**Multiple targets:**
```json
{
  "target": "platform1:user:123,platform2:channel:456",
  "text": "Broadcast message"
}
```

## Test plan
- [ ] Test sending message via n8n node with new format
- [ ] Verify multiple targets work with comma-separated format
- [ ] Test optional fields in n8n Additional Fields collection