### PR TITLE
fix: use Prisma v6 in Dockerfile and entrypoint to avoid v7 breaking changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ COPY prisma ./prisma/
 # Install all dependencies (including dev)
 RUN npm ci
 
-# Generate Prisma client
-RUN npx prisma generate
+# Generate Prisma client (use local version from package.json)
+RUN npm exec prisma generate
 
 # Copy backend source and tools
 COPY src ./src
@@ -87,8 +87,8 @@ RUN npm ci --only=production --legacy-peer-deps --ignore-scripts && \
     npm rebuild && \
     npm cache clean --force
 
-# Generate Prisma client for production
-RUN npx prisma generate
+# Generate Prisma client for production (explicit v6 to avoid v7 breaking changes)
+RUN npx prisma@6 generate
 
 # ==============================================================================
 # Stage 4: Final Production Image

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -28,7 +28,7 @@ BACKEND_PORT=${PORT:-7890}
 # Run database migrations
 echo "Running database migrations..."
 cd /app/backend
-npx prisma migrate deploy
+npx prisma@6 migrate deploy
 if [ $? -ne 0 ]; then
     echo "✗ Migration failed"
     exit 1

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -14,6 +14,8 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
+    // Ensure shared dependencies are resolved from web's node_modules
+    dedupe: ['axios'],
   },
   server: {
     port: parseInt(process.env.MSGCORE_PORT || '5173'),


### PR DESCRIPTION
## Summary

- Use `npm exec prisma generate` in backend-builder stage (uses local version from package.json)
- Use `npx prisma@6 generate` in backend-deps stage (explicit v6 since prisma is a devDependency)
- Use `npx prisma@6 migrate deploy` in runtime entrypoint
- Add axios to Vite `dedupe` config for web build resolution

## Problem

Prisma 7.x was released with breaking changes that remove the `url` property from `datasource` in schema files. When using `npx prisma` without a version, npm downloads the latest version (7.x) instead of using the version specified in package.json (6.16.3).

This caused Docker builds and runtime migrations to fail with:
```
error: The datasource property `url` is no longer supported in schema files.
```

## Test plan

- [x] Deployed successfully to msgcore-filipe via Dokku
- [x] Prisma migrations ran successfully with v6.19.1
- [x] Backend started and healthchecks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)